### PR TITLE
docs: reorganize README and add focused guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,210 +6,26 @@
 [![Release](https://img.shields.io/github/v/release/vmvarela/ghoten?logo=github)](https://github.com/vmvarela/ghoten/releases/latest)
 [![License: MPL 2.0](https://img.shields.io/github/license/vmvarela/ghoten)](LICENSE)
 
-**An [OpenTofu](https://opentofu.org/) fork with a native ORAS backend for OCI registry state storage.**
+## What is this?
 
-Ghoten adds a first-class **`oras`** backend that speaks the [OCI distribution protocol](https://oras.land/) directly. Use an OCI-compatible registry — such as GitHub Container Registry (GHCR) — as the durable store for your infrastructure state, without external HTTP backends or third-party wrappers.
+Ghoten is an [OpenTofu](https://opentofu.org/) fork that adds one opinionated thing: a native `oras` backend for storing state in OCI registries (like GHCR), without extra services.
 
-> **Upstream**: Ghoten tracks [OpenTofu](https://github.com/opentofu/opentofu) and carries only the additions required for the ORAS backend. All standard OpenTofu functionality is preserved.
+We built it for teams that already trust container registries and want fewer moving parts in Terraform/OpenTofu state management. Instead of running a custom HTTP backend, you can reuse registry auth, permissions, and auditing you already have.
 
----
+> **Upstream policy:** Ghoten tracks [OpenTofu](https://github.com/opentofu/opentofu) and keeps changes focused on the ORAS backend and related automation.
 
-## Key Features
+## Quick Start
 
-- **Native OCI storage** — State, locks, and versions stored as OCI artifacts via [ORAS](https://oras.land/)
-- **Atomic locking** — Generation semantics prevent concurrent lock holders
-- **Stale lock cleanup (TTL)** — Crashed-process locks auto-cleared on next acquisition
-- **State versioning** — Historical snapshots with async background retention cleanup
-- **Gzip compression** — Optional state compression before pushing
-- **Rate limiting & retry** — Token-bucket limiter + exponential backoff for transient errors
-- **GHCR deletion fallback** — Falls back to GitHub Packages API when OCI `DELETE` returns 405
-- **Docker credential helpers** — Reuses Docker config with caching and singleflight deduplication
-- **OpenTelemetry tracing** — All OCI HTTP calls instrumented via `otelhttp`
-- **Client-side encryption** — Combine with [OpenTofu state encryption](https://opentofu.org/docs/language/state/encryption/)
-
----
-
-## Installation
+Build and run `ghoten` locally:
 
 ```bash
-# Build from source
-git clone https://github.com/vmvarela/ghoten.git && cd ghoten
+git clone https://github.com/vmvarela/ghoten.git
+cd ghoten
 make build
-
-# Or pull Docker images
-docker pull ghcr.io/vmvarela/ghoten:<version>          # Alpine (git/bash/openssh)
-docker pull ghcr.io/vmvarela/ghoten:<version>-minimal   # Scratch (binary only)
+./ghoten version
 ```
 
-Pre-built binaries for 17 platform combinations are available on the [Releases](https://github.com/vmvarela/ghoten/releases) page.
-
----
-
-## GitHub Action
-
-Run Ghoten in your workflows with zero configuration — the action installs the binary, authenticates to GHCR, initializes the ORAS backend, and runs your command with **PR comments** and **Job Summaries** out of the box.
-
-Your HCL only needs an empty backend block — the action injects `repository`, `compression`, `lock_ttl`, and `max_versions` automatically:
-
-```hcl
-terraform {
-  backend "oras" {}
-}
-```
-
-### Quick Start
-
-```yaml
-on: pull_request
-
-jobs:
-  plan:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-      - uses: vmvarela/ghoten@v1
-```
-
-The action will install Ghoten, authenticate to GHCR, init with the ORAS backend (`ghcr.io/<owner>/tf-state.<repo>`), run `ghoten plan`, post a PR comment, and generate a Job Summary.
-
-### Plan on PR, Apply on Merge
-
-```yaml
-name: Infrastructure
-on:
-  pull_request:
-  push:
-    branches: [main]
-
-jobs:
-  plan:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions: { contents: read, packages: write, pull-requests: write }
-    steps:
-      - uses: actions/checkout@v6
-      - uses: vmvarela/ghoten@v1
-
-  apply:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions: { contents: read, packages: write }
-    steps:
-      - uses: actions/checkout@v6
-      - uses: vmvarela/ghoten@v1
-        with:
-          command: apply
-```
-
-### Inputs
-
-| Input | Default | Description |
-|---|---|---|
-| `command` | `plan` | `plan`, `apply`, `destroy`, `fmt`, `validate` |
-| `working-directory` | `.` | Path to HCL configuration files |
-| `workspace` | `default` | Terraform workspace |
-| `var-file` | | Path to a `.tfvars` file |
-| `variables` | | Newline-separated `key=value` pairs |
-| `backend-repository` | `ghcr.io/<owner>/tf-state.<repo>` | ORAS backend OCI repository |
-| `backend-config` | | Additional `-backend-config` key=value pairs |
-| `github-token` | `${{ github.token }}` | Token for GHCR auth and PR comments |
-| `comment-on-pr` | `true` | Post output as PR comment |
-| `add-summary` | `true` | Generate Job Summary |
-| `args` | | Additional CLI arguments |
-| `init-args` | | Additional arguments for `ghoten init` |
-| `auto-init` | `true` | Automatically run `ghoten init` |
-| `compression` | `gzip` | State compression: `none` or `gzip` |
-| `lock-ttl` | `300` | Lock TTL in seconds |
-| `max-versions` | `10` | State versions to retain |
-| `fmt-check` | `false` | Use `-check` mode for fmt |
-| `version` | *(auto)* | Ghoten version to install |
-
-### Outputs
-
-| Output | Description |
-|---|---|
-| `exitcode` | Exit code of the command |
-| `stdout` | Full command output |
-| `plan-has-changes` | `true`/`false` — whether plan detected changes |
-| `plan-file` | Path to binary plan file (when `command=plan`) |
-| `fmt-result` | `true`/`false` — whether fmt found differences |
-
-### More Examples
-
-```yaml
-# Format check
-- uses: vmvarela/ghoten@v1
-  with: { command: fmt, fmt-check: true }
-
-# With variables
-- uses: vmvarela/ghoten@v1
-  with:
-    command: plan
-    var-file: prod.tfvars
-    variables: |
-      region=eu-west-1
-      environment=production
-
-# Custom backend repository
-- uses: vmvarela/ghoten@v1
-  with:
-    command: plan
-    backend-repository: ghcr.io/myorg/custom-state-repo
-
-# Plan → Apply in same job
-- uses: vmvarela/ghoten@v1
-  id: plan
-  with: { command: plan }
-- uses: vmvarela/ghoten@v1
-  if: steps.plan.outputs.plan-has-changes == 'true'
-  with: { command: apply }
-```
-
-### Permissions
-
-| Permission | Required for |
-|---|---|
-| `contents: read` | Repository checkout |
-| `packages: write` | ORAS backend (read/write/delete state on GHCR) |
-| `pull-requests: write` | PR comments (optional) |
-
-> `packages: write` covers version retention cleanup. The separate `delete:packages` permission is only needed to delete entire packages from GHCR.
-
----
-
-## ORAS Backend
-
-### Configuration
-
-| Parameter | Type | Default | Env Var | Description |
-|---|---|---|---|---|
-| `repository` | string | `""` | `TF_BACKEND_ORAS_REPOSITORY` | OCI repository (`<registry>/<repo>`). **Required.** |
-| `compression` | string | `"none"` | — | `none` or `gzip` |
-| `insecure` | bool | `false` | — | Skip TLS verification |
-| `ca_file` | string | `""` | — | PEM-encoded CA bundle path |
-| `retry_max` | int | `2` | `TF_BACKEND_ORAS_RETRY_MAX` | Retries for transient errors |
-| `retry_wait_min` | int | `1` | `TF_BACKEND_ORAS_RETRY_WAIT_MIN` | Min backoff (seconds) |
-| `retry_wait_max` | int | `30` | `TF_BACKEND_ORAS_RETRY_WAIT_MAX` | Max backoff (seconds) |
-| `lock_ttl` | int | `0` | `TF_BACKEND_ORAS_LOCK_TTL` | Lock TTL (seconds). `> 0` enables stale-lock clearing |
-| `rate_limit` | int | `0` | `TF_BACKEND_ORAS_RATE_LIMIT` | Max requests/sec. `0` disables |
-| `rate_limit_burst` | int | `0` | `TF_BACKEND_ORAS_RATE_LIMIT_BURST` | Burst size |
-| `max_versions` | int | `0` | — | State versions to retain. `0` disables |
-
-### Usage Examples
-
-**With the GitHub Action** — just declare an empty backend; the action provides everything via env vars and `-backend-config`:
-
-```hcl
-terraform {
-  backend "oras" {}
-}
-```
-
-**Standalone — minimal:**
+Use ORAS backend in your HCL:
 
 ```hcl
 terraform {
@@ -219,102 +35,34 @@ terraform {
 }
 ```
 
-**Standalone — production-ready:**
-
-```hcl
-terraform {
-  backend "oras" {
-    repository   = "ghcr.io/myorg/infra-state"
-    compression  = "gzip"
-    lock_ttl     = 300
-    max_versions = 10
-  }
-
-  encryption {
-    key_provider "pbkdf2" "main" {
-      passphrase = var.state_passphrase
-    }
-    method "aes_gcm" "main" {
-      key_provider = key_provider.pbkdf2.main
-    }
-    state { method = method.aes_gcm.main }
-    plan  { method = method.aes_gcm.main }
-  }
-}
-```
-
-> **Tip**: For production, prefer a KMS-backed key provider (AWS KMS, GCP KMS, etc.) over PBKDF2.
-
-### Authentication
-
-Credentials are discovered in order:
-
-1. **Docker credential helpers** — Docker config / credential store (cached, singleflight-deduplicated)
-2. **CLI host credentials** — OpenTofu/Terraform login tokens (`ghoten login`)
-
-### How State Is Stored
-
-Tags act as stable references inside the OCI repository:
-
-| Purpose | Tag pattern |
-|---|---|
-| State | `state-<workspace>` |
-| Lock | `locked-<workspace>` |
-| Version | `state-<workspace>-v<N>` |
-
-> If the workspace name is not a valid OCI tag, a `ws-<sha256>` form is used instead, with the real name persisted in OCI annotations.
-
-<details><summary><b>Wire format details</b></summary>
-
-**State objects** (ORAS manifest v1.1):
-- `artifactType`: `application/vnd.terraform.state.v1`
-- Layer: `application/vnd.terraform.statefile.v1` (or `+gzip`)
-- Annotations: `org.terraform.workspace`, `org.terraform.state.updated_at`
-
-**Lock objects**:
-- `artifactType`: `application/vnd.terraform.lock.v1`
-- Annotations: `org.terraform.workspace`, `org.terraform.lock.id`, `org.terraform.lock.info`, `org.terraform.lock.generation`
-
-</details>
-
-### Security
-
-- **Enable [client-side encryption](https://opentofu.org/docs/language/state/encryption/)** — encrypts state before it leaves your machine
-- Keep the repository **private** with **least-privilege** tokens
-- Prefer registries with **encryption at rest** and **audit trails**
-
-> **Note**: Primarily tested against GHCR. Other OCI registries should work but are not yet validated.
-
----
-
-## Testing
+Authenticate and initialize with GHCR:
 
 ```bash
-go test ./...                                        # Full suite
-go test ./internal/backend/remote-state/oras/...     # ORAS backend (in-memory fake registry)
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USER --password-stdin
+./ghoten init
+./ghoten plan
 ```
 
----
+## Why this approach?
 
-## Troubleshooting
+- **Registry-first state**: state, locks, and versions are OCI artifacts.
+- **Operationally simple**: no separate backend service to deploy and maintain.
+- **Safe by default**: locking, retries, and optional compression are built in.
+- **Works in GitHub Actions**: action handles install, auth, init, PR comments, and summaries.
 
-| Problem | Solution |
-|---|---|
-| **"unauthorized" / "denied"** | Verify `docker login <registry>`. For GHCR: `read:packages` + `write:packages` (+ `delete:packages` if retention enabled) |
-| **Lock stuck after crash** | Set `lock_ttl = 300` — next run auto-clears it. Or delete `locked-<workspace>` tag manually |
-| **Version deletion fails on GHCR** | Backend falls back to GitHub Packages API automatically. Ensure `delete:packages` permission |
-| **Debug output** | `TF_LOG=DEBUG ghoten plan` |
+## Documentation
 
----
+- [Quickstart & installation](docs/quickstart.md)
+- [GitHub Action guide](docs/github-action.md)
+- [ORAS backend guide](docs/oras-backend.md)
+- [Testing guide](docs/testing.md)
+- [Contributing](CONTRIBUTING.md)
+- [Security policy](SECURITY.md)
 
-## Contributing
+## Limitations
 
-- [GitHub Issues](https://github.com/vmvarela/ghoten/issues) · [Contributing Guide](CONTRIBUTING.md) · [Code of Conduct](CODE_OF_CONDUCT.md)
-- For upstream questions: [OpenTofu Discussions](https://github.com/orgs/opentofu/discussions)
-
-## Security
-
-Report vulnerabilities via [GitHub Security Advisories](https://github.com/vmvarela/ghoten/security/advisories/new). See [SECURITY.md](SECURITY.md).
+- Most production validation so far is on GHCR; other OCI registries are expected to work but are less battle-tested.
+- If you need advanced backend workflows (multi-region replication policies, custom APIs), dedicated backend platforms may be a better fit.
 
 ## License
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,0 +1,98 @@
+# GitHub Action Guide
+
+## What is this?
+
+`vmvarela/ghoten@v1` is the fastest way to run OpenTofu with OCI-backed state in GitHub Actions. It installs `ghoten`, authenticates to GHCR, initializes the ORAS backend, runs your command, and can post PR comments plus a job summary.
+
+Use the action unless you have a strong reason to script every step manually. You get fewer moving parts and fewer auth mistakes.
+
+## Minimal PR plan workflow
+
+Use this when you want plan output in pull requests with almost no setup:
+
+```yaml
+name: Infra Plan
+on: pull_request
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: vmvarela/ghoten@v1
+```
+
+This defaults to `command: plan`, posts a PR comment, and writes a Job Summary.
+
+## Plan on PR, apply on main
+
+Use this split when you want safe review before mutation:
+
+```yaml
+name: Infrastructure
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  plan:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write, pull-requests: write }
+    steps:
+      - uses: actions/checkout@v6
+      - uses: vmvarela/ghoten@v1
+
+  apply:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions: { contents: read, packages: write }
+    steps:
+      - uses: actions/checkout@v6
+      - uses: vmvarela/ghoten@v1
+        with:
+          command: apply
+```
+
+## Inputs you will actually tweak
+
+Most users only need these:
+
+| Input | Default | Why you change it |
+|---|---|---|
+| `command` | `plan` | Switch to `apply`, `destroy`, `fmt`, or `validate` |
+| `working-directory` | `.` | Monorepo or nested IaC folders |
+| `backend-repository` | `ghcr.io/<owner>/tf-state.<repo>` | Shared state repo naming conventions |
+| `var-file` | `""` | Load environment-specific variables |
+| `variables` | `""` | Inject small runtime values in CI |
+| `comment-on-pr` | `true` | Disable PR noise in very large repos |
+| `add-summary` | `true` | Disable if you already publish custom summaries |
+
+The backend-related defaults (`compression=gzip`, `lock-ttl=300`, `max-versions=10`) are sensible for most teams. Keep them unless you have measured reasons to change.
+
+## Useful output wiring
+
+Use action outputs to gate later steps:
+
+```yaml
+- uses: vmvarela/ghoten@v1
+  id: plan
+  with: { command: plan }
+
+- uses: vmvarela/ghoten@v1
+  if: steps.plan.outputs.plan-has-changes == 'true'
+  with: { command: apply }
+```
+
+## Permissions checklist
+
+- `contents: read` for checkout.
+- `packages: write` for GHCR state read/write/delete.
+- `pull-requests: write` only if you want PR comments.
+
+If you enable aggressive retention/deletion workflows, ensure the token has enough package permissions in your org policy.

--- a/docs/oras-backend.md
+++ b/docs/oras-backend.md
@@ -1,0 +1,95 @@
+# ORAS Backend Guide
+
+## What is this?
+
+The `oras` backend stores OpenTofu state directly as OCI artifacts. Instead of running an HTTP backend service, you use an OCI registry you already operate (for many teams: GHCR).
+
+This backend is a good fit when your org already has registry auth, audit trails, and permissions in place. It is not ideal if you need backend-specific APIs or advanced policy engines that OCI registries do not provide.
+
+## Minimal config
+
+This is the smallest valid backend configuration:
+
+```hcl
+terraform {
+  backend "oras" {
+    repository = "ghcr.io/acme/infra-state"
+  }
+}
+```
+
+`repository` is the one required setting. Everything else is optional tuning.
+
+## Production baseline
+
+Use this baseline first, then optimize only if you observe concrete bottlenecks:
+
+```hcl
+terraform {
+  backend "oras" {
+    repository   = "ghcr.io/myorg/infra-state"
+    compression  = "gzip"
+    lock_ttl     = 300
+    max_versions = 10
+  }
+
+  encryption {
+    key_provider "pbkdf2" "main" {
+      passphrase = var.state_passphrase
+    }
+    method "aes_gcm" "main" {
+      key_provider = key_provider.pbkdf2.main
+    }
+    state { method = method.aes_gcm.main }
+    plan  { method = method.aes_gcm.main }
+  }
+}
+```
+
+For real production systems, prefer a KMS-backed key provider over PBKDF2 passphrases.
+
+## Configuration reference
+
+| Parameter | Type | Default | Env Var | Notes |
+|---|---|---|---|---|
+| `repository` | string | `""` | `TF_BACKEND_ORAS_REPOSITORY` | Required OCI repo (`<registry>/<repo>`) |
+| `compression` | string | `"none"` | — | `none` or `gzip` |
+| `insecure` | bool | `false` | — | Skip TLS verification |
+| `ca_file` | string | `""` | — | PEM CA bundle path |
+| `retry_max` | int | `2` | `TF_BACKEND_ORAS_RETRY_MAX` | Retry count for transient errors |
+| `retry_wait_min` | int | `1` | `TF_BACKEND_ORAS_RETRY_WAIT_MIN` | Backoff min (seconds) |
+| `retry_wait_max` | int | `30` | `TF_BACKEND_ORAS_RETRY_WAIT_MAX` | Backoff max (seconds) |
+| `lock_ttl` | int | `0` | `TF_BACKEND_ORAS_LOCK_TTL` | `> 0` enables stale-lock cleanup |
+| `rate_limit` | int | `0` | `TF_BACKEND_ORAS_RATE_LIMIT` | Requests/sec, `0` disables |
+| `rate_limit_burst` | int | `0` | `TF_BACKEND_ORAS_RATE_LIMIT_BURST` | Token bucket burst |
+| `max_versions` | int | `0` | — | Historical versions to keep |
+
+## How state is represented
+
+Tags are stable pointers inside your OCI repository:
+
+| Purpose | Tag pattern |
+|---|---|
+| Current state | `state-<workspace>` |
+| Active lock | `locked-<workspace>` |
+| Historical version | `state-<workspace>-v<N>` |
+
+When a workspace name is not a valid OCI tag, Ghoten hashes it to `ws-<sha256>` and stores the original name in annotations.
+
+## Auth resolution order
+
+Ghoten resolves credentials in this order:
+
+1. Docker credential helpers (`docker login`, credential store)
+2. CLI host credentials (`ghoten login` / Terraform-style host tokens)
+
+If auth fails, run `docker login <registry>` first; it fixes most cases faster than tweaking backend flags.
+
+## Troubleshooting
+
+| Problem | What to do |
+|---|---|
+| `unauthorized` or `denied` | Re-run `docker login`. On GHCR, ensure `read:packages` and `write:packages` scopes |
+| Lock appears stuck | Set `lock_ttl = 300` to auto-clear stale locks on next acquisition |
+| Deleting versions fails on GHCR | Ghoten falls back to GitHub Packages API; ensure package delete permission is granted |
+| Need deep diagnostics | Run with `TF_LOG=DEBUG ./ghoten plan` |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,75 @@
+# Quickstart
+
+## What is this?
+
+This guide gets you from clone to a working `ghoten plan` with an OCI-backed state in minutes. It focuses on the happy path and skips optional flags.
+
+If you need full backend tuning (`retry`, `rate_limit`, TLS options), use the ORAS backend guide after this one.
+
+## Local install in 4 commands
+
+```bash
+git clone https://github.com/vmvarela/ghoten.git
+cd ghoten
+make build
+./ghoten version
+```
+
+For CI or reproducible local environments, you can also use the published image:
+
+```bash
+docker pull ghcr.io/vmvarela/ghoten:<version>
+```
+
+## Minimal ORAS backend config
+
+Start with the one setting that matters: the OCI repository.
+
+```hcl
+terraform {
+  backend "oras" {
+    repository = "ghcr.io/acme/infra-state"
+  }
+}
+```
+
+This is enough to run. Add compression and retention only after the basics work.
+
+## Authenticate and run
+
+Login once, then initialize and plan.
+
+```bash
+echo "$GITHUB_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USER --password-stdin
+./ghoten init
+./ghoten plan
+```
+
+When things fail, use debug logs immediately instead of guessing:
+
+```bash
+TF_LOG=DEBUG ./ghoten plan
+```
+
+## Production baseline
+
+Once the minimal setup works, this is the baseline we recommend for most teams:
+
+```hcl
+terraform {
+  backend "oras" {
+    repository   = "ghcr.io/myorg/infra-state"
+    compression  = "gzip"
+    lock_ttl     = 300
+    max_versions = 10
+  }
+}
+```
+
+`lock_ttl` avoids manual cleanup after crashed jobs, and `max_versions` keeps history without unbounded growth.
+
+## Next steps
+
+- For CI pipelines, continue with [GitHub Action guide](github-action.md).
+- For backend details and wire format, continue with [ORAS backend guide](oras-backend.md).
+- For running tests locally and in CI, continue with [Testing guide](testing.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,57 @@
+# Testing Guide
+
+## What is this?
+
+This guide shows the shortest path to confidence when changing Ghoten: run fast unit tests first, then targeted backend/integration tests only when your change needs them.
+
+That order is intentional. Full integration sweeps are expensive; most regressions are caught earlier with package-level tests.
+
+## Fast feedback loop
+
+Start here for almost every change:
+
+```bash
+go test -v ./...
+```
+
+If you are changing ORAS backend behavior, run its focused suite directly:
+
+```bash
+go test ./internal/backend/remote-state/oras/...
+```
+
+## Coverage run
+
+Use this when validating broad impact before release:
+
+```bash
+make test-with-coverage
+```
+
+This generates `coverage.out` and `coverage.html` at the repository root.
+
+## Integration test targets
+
+Use integration tests only when touching backend-specific runtime behavior.
+
+| Target | What it validates | Key requirement |
+|---|---|---|
+| `make test-s3` | S3 remote-state backend behavior | AWS credentials + IAM permissions |
+| `make test-gcp` | GCS remote-state backend behavior | GCP ADC + project/region env vars |
+| `make test-pg` | PostgreSQL remote-state backend behavior | Docker + local port `5432` |
+| `make test-consul` | Consul remote-state backend behavior | Docker |
+| `make test-kubernetes` | Kubernetes backend behavior | Docker + kind prerequisites |
+
+List all integration helpers with:
+
+```bash
+make list-integration-tests
+```
+
+## Recommended workflow
+
+1. `go test -v ./...`
+2. Run a focused package test for the area you changed.
+3. Run one integration target only if your change touches that backend.
+
+This keeps CI time and local feedback fast without skipping meaningful validation.


### PR DESCRIPTION
## Summary
- Rewrite `README.md` as a concise front door focused on the project’s big idea and quick start
- Add focused documentation pages under `docs/`:
  - `docs/quickstart.md`
  - `docs/github-action.md`
  - `docs/oras-backend.md`
  - `docs/testing.md`
- Link all new guides from the README

## Why
The previous README had grown too large for onboarding. This PR splits content by concern to keep the main README short and practical, while preserving detailed guidance in dedicated docs.

## Scope
Documentation only. No runtime or code behavior changes.
