### PR TITLE
docs: add scrum-process.md with sprint cadence and label workflow

### DIFF
--- a/docs/scrum-process.md
+++ b/docs/scrum-process.md
@@ -1,0 +1,118 @@
+# Scrum Process
+
+How this repository runs planning, delivery, and review. Adapted for a solo developer or small team (1–3 people).
+
+---
+
+## Rhythm
+
+| Event | When | Duration |
+|---|---|---|
+| Sprint Planning | Start of each sprint | 30 min |
+| Daily check-in | Optional, async (comment in issue) | — |
+| Sprint Review | End of sprint | 30 min |
+| Sprint Retrospective | After review, same day | 20 min |
+
+**Sprint length: 1 week** (solo) or **2 weeks** (small team).
+
+---
+
+## Milestones = Sprints
+
+Each sprint is a GitHub Milestone.
+
+**Naming:** `Sprint N` (e.g., `Sprint 1`, `Sprint 2`)
+
+**Sprint Goal format** (milestone description):
+```
+Sprint Goal: <one sentence describing the most valuable outcome of this sprint>
+```
+
+Example:
+```
+Sprint Goal: Establish a working Scrum loop in GitHub with labels, templates, and sprint hygiene.
+```
+
+The goal must be short enough to fit in the milestone description and answer: *"Why is this sprint worth running?"*
+
+---
+
+## Labels in the development workflow
+
+### Type — what kind of work it is
+
+| Label | Use for |
+|---|---|
+| `type:feature` | New functionality |
+| `type:bug` | Something broken that needs fixing |
+| `type:chore` | Maintenance, refactoring, tooling |
+| `type:spike` | Timeboxed research or investigation |
+| `type:docs` | Documentation only |
+
+### Priority — when to pick it up
+
+| Label | Meaning |
+|---|---|
+| `priority:critical` | Must fix immediately — blocks everything |
+| `priority:high` | Must be in the next sprint |
+| `priority:medium` | Should be done soon |
+| `priority:low` | Nice to have; pick up when capacity allows |
+
+### Size — relative effort estimate
+
+| Label | Rough effort |
+|---|---|
+| `size:xs` | < 1 hour |
+| `size:s` | 1–4 hours |
+| `size:m` | 4–8 hours |
+| `size:l` | 1–2 days |
+| `size:xl` | > 2 days — **split before starting** |
+
+### Status — where the issue is right now
+
+Apply **one status label** at a time. Change it as the issue moves through the workflow:
+
+| Label | Apply when… |
+|---|---|
+| *(none)* | Issue is in the backlog, not yet refined |
+| `status:in-progress` | Work has started (branch created, actively coding) |
+
+**Workflow:**
+
+```
+Backlog → [assign to sprint] → status:in-progress → [PR merged / done] → closed
+```
+
+Remove the status label when closing. An issue with no open status label + closed state = done.
+
+---
+
+## Sprint Planning checklist
+
+1. Review the backlog — pick issues with `priority:high` or `priority:medium`
+2. Ensure every picked issue has acceptance criteria and a size label
+3. Set the Milestone on each selected issue
+4. Add `status:in-progress` as you start each issue during the sprint
+
+## Sprint Review checklist
+
+1. Close all completed issues (reference commit or PR in the closing comment)
+2. Move incomplete issues back to the backlog (remove milestone)
+3. Publish a GitHub Release if there is a usable increment
+4. Close the milestone
+
+## Sprint Retrospective
+
+Create an issue with label `type:docs` titled `Retrospective: Sprint N` and answer:
+
+- What went well?
+- What could be improved?
+- Action items for the next sprint (as checkboxes)
+
+---
+
+## Backlog rules
+
+- Every issue must have: `type:*`, `priority:*`, `size:*`
+- Issues labeled `size:xl` must be split before they can be assigned to a sprint
+- Acceptance criteria (checklist) are required before an issue is sprint-ready

--- a/go.sum
+++ b/go.sum
@@ -721,8 +721,6 @@ golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMx
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
-golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -794,9 +792,6 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.41.0 h1:a9b8iMweWG+S0OBnlU36rzLp20z1Rp10w+IY2czHTQc=
 golang.org/x/tools v0.41.0/go.mod h1:XSY6eDqxVNiYgezAVqqCeihT4j1U2CCsqvH3WhQpnlg=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
## Summary

Adds `docs/scrum-process.md` documenting how this repository runs Scrum, adapted for a solo/small-team setup.

## What's included

- Sprint length and event schedule (planning, review, retrospective)
- Milestone naming convention and Sprint Goal format
- Full label reference (type, priority, size, status) with guidance on when to apply each
- Development workflow: backlog → in-progress → closed
- Sprint planning and review checklists
- Backlog rules (split `size:xl` before sprint, acceptance criteria required)

Closes #12