### PR TITLE
fix: track ORAS retention goroutines with sync.WaitGroup (#58)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ dist/
 # Development temp folder
 tmp
 .act/
+
+.agents/
+skills-lock.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ dist/
 tmp
 .act/
 
+# IA
+AGENTS.md
 .agents/
 skills-lock.json
-

--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -17,13 +17,13 @@ import (
 	"github.com/vmvarela/ghoten/internal/addrs"
 	"github.com/vmvarela/ghoten/internal/backend"
 	"github.com/vmvarela/ghoten/internal/command/views"
+	"github.com/vmvarela/ghoten/internal/ghoten"
 	"github.com/vmvarela/ghoten/internal/logging"
 	"github.com/vmvarela/ghoten/internal/plans"
 	"github.com/vmvarela/ghoten/internal/states"
 	"github.com/vmvarela/ghoten/internal/states/statefile"
 	"github.com/vmvarela/ghoten/internal/states/statemgr"
 	"github.com/vmvarela/ghoten/internal/tfdiags"
-	"github.com/vmvarela/ghoten/internal/ghoten"
 )
 
 // test hook called between plan+apply during opApply
@@ -302,6 +302,14 @@ func (b *Local) opApply(
 		diags = diags.Append(b.backupStateForError(stateFile, err, op.View))
 		op.ReportResult(runningOp, diags)
 		return
+	}
+
+	// Wait for any async background work (e.g., ORAS version-tag pruning)
+	// to complete before we return and the process potentially exits.
+	// This is a no-op for state managers that don't support retention waiting.
+	// Fixes the CLI exit race described in GitHub issue #58.
+	if rw, ok := opState.(interface{ WaitForRetention() }); ok {
+		rw.WaitForRetention()
 	}
 
 	if applyDiags.HasErrors() {

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -126,6 +126,14 @@ func (b *Local) opRefresh(
 		return
 	}
 
+	// Wait for any async background work (e.g., ORAS version-tag pruning)
+	// to complete before we return and the process potentially exits.
+	// This is a no-op for state managers that don't support retention waiting.
+	// Fixes the CLI exit race described in GitHub issue #58.
+	if rw, ok := opState.(interface{ WaitForRetention() }); ok {
+		rw.WaitForRetention()
+	}
+
 	// Show any remaining warnings before exiting
 	op.ReportResult(runningOp, diags)
 }

--- a/internal/backend/remote-state/oras/client.go
+++ b/internal/backend/remote-state/oras/client.go
@@ -217,6 +217,27 @@ type RemoteClient struct {
 	// retentionSem limits concurrent async retention goroutines.
 	// If nil, defaultRetentionSem is used.
 	retentionSem chan struct{}
+
+	// retentionWg tracks all in-flight async retention goroutines.
+	// Invariant: counter == N(g : g launched by put() and not yet returned : true)
+	// WaitForRetention blocks until the counter reaches zero, guaranteeing
+	// all version-pruning work completes before the caller proceeds.
+	retentionWg sync.WaitGroup
+}
+
+// WaitForRetention blocks until all in-flight async retention goroutines
+// launched by put() have completed.
+//
+// Pre:  true
+// Post: ∀ goroutine G previously launched by put(): G has returned
+//
+//	∧ N(v : v ∈ versionTags(repo, workspaceName) : true) ≤ versioningMaxVersions
+//
+// Call this before process exit when versioningMaxVersions > 0 to guarantee
+// that old version tags are pruned even when the CLI exits shortly after a
+// state write (fixes the race described in GitHub issue #58).
+func (c *RemoteClient) WaitForRetention() {
+	c.retentionWg.Wait()
 }
 
 type digestGroup struct {
@@ -393,7 +414,12 @@ func (c *RemoteClient) put(ctx context.Context, state []byte) error {
 	}
 	select {
 	case sem <- struct{}{}:
+		// Add(1) happens on the calling goroutine, before launch, so that any
+		// concurrent WaitForRetention() cannot observe a zero counter between
+		// the goroutine being scheduled and its first instruction executing.
+		c.retentionWg.Add(1)
 		go func() {
+			defer c.retentionWg.Done()
 			defer func() { <-sem }()
 			asyncCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()

--- a/internal/backend/remote-state/oras/client_test.go
+++ b/internal/backend/remote-state/oras/client_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/vmvarela/ghoten/internal/states/remote"
 	"github.com/vmvarela/ghoten/internal/states/statemgr"
 	orasErrcode "oras.land/oras-go/v2/registry/remote/errcode"
 )
@@ -346,16 +345,13 @@ func TestWorkspaces_NoDuplicateDefault(t *testing.T) {
 }
 
 func TestRemoteClient_Put_VersioningTagsAndRetention(t *testing.T) {
-	// Drain the global retention semaphore to ensure slots are available.
-	// Other tests may leave goroutines that hold semaphore slots.
-	drainRetentionSem()
-
 	ctx := context.Background()
 	fake := newFakeORASRepo()
 	repo := &orasRepositoryClient{inner: fake}
 
 	c := newRemoteClient(repo, "default")
 	c.versioningMaxVersions = 2
+	c.retentionSem = make(chan struct{}, 3) // isolated semaphore — no cross-test interference
 	if err := c.Put(ctx, []byte("s1")); err != nil {
 		t.Fatalf("put s1: %v", err)
 	}
@@ -366,17 +362,9 @@ func TestRemoteClient_Put_VersioningTagsAndRetention(t *testing.T) {
 		t.Fatalf("put s3: %v", err)
 	}
 
-	// Poll for async cleanup completion with timeout
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		if _, err := fake.Resolve(ctx, c.versionTagFor(1)); err != nil {
-			break // v1 deleted, cleanup completed
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for async retention to delete v1")
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	// WaitForRetention replaces the previous drainRetentionSem+polling loop.
+	// Post: all goroutines launched by put() have returned before we assert.
+	c.WaitForRetention()
 
 	p, err := c.Get(ctx)
 	if err != nil {
@@ -1056,6 +1044,7 @@ func TestAsyncRetentionNotBlocking(t *testing.T) {
 	repo := &orasRepositoryClient{inner: fake}
 	client := newRemoteClient(repo, "default")
 	client.versioningMaxVersions = 2
+	client.retentionSem = make(chan struct{}, 3) // isolated semaphore
 
 	// Push multiple states - async retention should not block
 	start := time.Now()
@@ -1066,25 +1055,18 @@ func TestAsyncRetentionNotBlocking(t *testing.T) {
 	}
 	duration := time.Since(start)
 
-	// Async should be fast (< 100ms even with cleanup running)
-	// Inline would take longer due to cleanup blocking
+	// Async should be fast (< 500ms even with cleanup running)
 	if duration > 500*time.Millisecond {
 		t.Logf("async retention took %v (expected < 500ms for 3 puts)", duration)
 	}
 
-	// Poll for state to be readable with timeout
-	deadline := time.Now().Add(2 * time.Second)
-	var payload *remote.Payload
-	var err error
-	for {
-		payload, err = client.Get(ctx)
-		if err == nil && payload != nil {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for state to be written; last error: %v", err)
-		}
-		time.Sleep(10 * time.Millisecond)
+	// Wait for all retention goroutines to finish before checking state.
+	// This replaces the previous polling loop with a deterministic synchronisation.
+	client.WaitForRetention()
+
+	payload, err := client.Get(ctx)
+	if err != nil || payload == nil {
+		t.Fatalf("expected state to be readable after WaitForRetention; err=%v payload=%v", err, payload)
 	}
 }
 
@@ -1127,18 +1109,20 @@ func TestRemoteClient_Delete(t *testing.T) {
 }
 
 func TestRemoteClient_Delete_WithVersioning(t *testing.T) {
-	drainRetentionSem()
 	ctx := context.Background()
 	fake := newFakeORASRepo()
 	repo := &orasRepositoryClient{inner: fake}
 
 	client := newRemoteClient(repo, "default")
 	client.versioningMaxVersions = 5
+	client.retentionSem = make(chan struct{}, 3) // isolated semaphore
 
 	// Put state to create the main tag and a version tag.
 	if err := client.Put(ctx, []byte("versioned-state")); err != nil {
 		t.Fatalf("put: %v", err)
 	}
+	// Ensure all retention goroutines have completed before asserting tag state.
+	client.WaitForRetention()
 
 	// Verify both tags exist.
 	if _, err := fake.Resolve(ctx, client.stateTag); err != nil {
@@ -1195,6 +1179,170 @@ func TestRemoteClient_RetagToNewManifest_PreservesVersionAnnotation(t *testing.T
 	if v := fm2.m.Annotations[annotationStateVersion]; v != "1" {
 		t.Fatalf("expected preserved version annotation '1' after retag, got %q", v)
 	}
+}
+
+// ─── Regression tests for issue #58 ──────────────────────────────────────────
+//
+// Issue: async retention goroutines are fire-and-forget; the CLI exits via
+// os.Exit before they complete, leaving more version tags than max_versions.
+//
+// Fix: RemoteClient.retentionWg tracks every goroutine launched by put().
+// WaitForRetention() blocks until the counter reaches zero.
+
+// TestRetentionCompleteAfterWait verifies the core postcondition of the fix:
+//
+//	Post: after WaitForRetention() returns,
+//	      N(v : v ∈ versionTags(repo, workspace) : true) ≤ versioningMaxVersions
+//
+// The test is fully deterministic — no time.Sleep, no polling — which is only
+// possible because WaitForRetention() provides the synchronisation guarantee.
+func TestRetentionCompleteAfterWait(t *testing.T) {
+	// Pre: fake in-memory repo, maxVersions = 2, 5 sequential Put calls.
+	const maxVersions = 2
+	const numPuts = 5
+
+	ctx := context.Background()
+	fake := newFakeORASRepo()
+	repo := &orasRepositoryClient{inner: fake}
+
+	c := newRemoteClient(repo, "default")
+	c.versioningMaxVersions = maxVersions
+	c.retentionSem = make(chan struct{}, 3) // isolated semaphore
+
+	for i := 1; i <= numPuts; i++ {
+		if err := c.Put(ctx, []byte(fmt.Sprintf("state-%d", i))); err != nil {
+			t.Fatalf("Put(%d): %v", i, err)
+		}
+	}
+
+	// WaitForRetention must block until all goroutines launched by put() return.
+	// Post obligation: every version tag beyond the retention limit is gone.
+	c.WaitForRetention()
+
+	// Count surviving version tags immediately after Wait — no sleep, no poll.
+	surviving := 0
+	for v := 1; v <= numPuts; v++ {
+		if _, err := fake.Resolve(ctx, c.versionTagFor(v)); err == nil {
+			surviving++
+		}
+	}
+
+	// Post: surviving ≤ maxVersions
+	if surviving > maxVersions {
+		t.Errorf("after WaitForRetention: %d version tags survive, want ≤ %d (issue #58)",
+			surviving, maxVersions)
+	}
+}
+
+// TestRetentionRaceWithoutWait documents the original bug: without
+// WaitForRetention, the goroutines may not finish before the caller proceeds,
+// so more than max_versions tags can survive.
+//
+// The test uses a blocking fake repo whose Delete is artificially delayed so
+// that the goroutines are provably still in-flight at the assertion point.
+// This makes the failure deterministic rather than timing-dependent.
+//
+//	Pre:  deleteDelay >> assertion window (1 ms << 50 ms)
+//	Post: without Wait, surviving > maxVersions  (bug present)
+func TestRetentionRaceWithoutWait(t *testing.T) {
+	const maxVersions = 2
+	const numPuts = 5
+
+	ctx := context.Background()
+	fake := newFakeORASRepo()
+
+	// slowRepo wraps fakeORASRepo and introduces a delay on every Delete call,
+	// ensuring the retention goroutine is still in-flight when we assert below.
+	slow := &slowDeleteRepo{
+		delegatingRepo: delegatingRepo{inner: fake},
+		deleteDelay:    50 * time.Millisecond,
+	}
+	repo := &orasRepositoryClient{inner: slow}
+
+	c := newRemoteClient(repo, "default")
+	c.versioningMaxVersions = maxVersions
+	c.retentionSem = make(chan struct{}, 3)
+
+	for i := 1; i <= numPuts; i++ {
+		if err := c.Put(ctx, []byte(fmt.Sprintf("state-%d", i))); err != nil {
+			t.Fatalf("Put(%d): %v", i, err)
+		}
+	}
+
+	// Do NOT call WaitForRetention — simulate an immediate os.Exit.
+	// The retention goroutines are still sleeping in slowDeleteRepo.Delete,
+	// so all version tags must still be present.
+	surviving := 0
+	for v := 1; v <= numPuts; v++ {
+		if _, err := fake.Resolve(ctx, c.versionTagFor(v)); err == nil {
+			surviving++
+		}
+	}
+
+	// Without Wait the goroutines haven't deleted anything yet.
+	// Post (bug behaviour): surviving == numPuts > maxVersions.
+	if surviving <= maxVersions {
+		t.Skipf("retention finished before assertion (race); surviving=%d maxVersions=%d",
+			surviving, maxVersions)
+	}
+
+	// Wait now so the goroutines can clean up — avoids leaking goroutines in tests.
+	c.WaitForRetention()
+}
+
+// TestWaitForRetentionIsIdempotent verifies that calling WaitForRetention when
+// no versioning is enabled (versioningMaxVersions == 0) returns immediately.
+//
+//	Pre:  versioningMaxVersions == 0, any number of Put calls
+//	Post: WaitForRetention() returns without blocking
+func TestWaitForRetentionIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	fake := newFakeORASRepo()
+	repo := &orasRepositoryClient{inner: fake}
+
+	c := newRemoteClient(repo, "default")
+	// versioningMaxVersions == 0: no goroutines are launched
+	if err := c.Put(ctx, []byte("state-no-versioning")); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		c.WaitForRetention()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Post satisfied: returned without blocking.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("WaitForRetention blocked when no goroutines were launched")
+	}
+}
+
+// ─── Test helpers ────────────────────────────────────────────────────────────
+
+// slowDeleteRepo wraps an inner repository and introduces a configurable delay
+// on every Delete call, making retention goroutines deterministically in-flight
+// at the moment the test makes its assertion (issue #58 regression test).
+//
+// Pre:  deleteDelay ≥ 0
+// Post: every Delete blocks for deleteDelay before delegating to inner.Delete
+type slowDeleteRepo struct {
+	delegatingRepo
+	deleteDelay time.Duration
+}
+
+func (r *slowDeleteRepo) Delete(ctx context.Context, target ocispec.Descriptor) error {
+	// Block for deleteDelay, respecting context cancellation.
+	// Pre:  deleteDelay ≥ 0
+	// Post: either deleteDelay has elapsed, or ctx was cancelled
+	select {
+	case <-time.After(r.deleteDelay):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	return r.delegatingRepo.inner.Delete(ctx, target)
 }
 
 // noopLogger satisfies the logger interface used by retagToNewManifest.

--- a/internal/backend/remote-state/oras/helper_test.go
+++ b/internal/backend/remote-state/oras/helper_test.go
@@ -7,35 +7,11 @@ import (
 	"io"
 	"sort"
 	"sync"
-	"time"
 
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/errdef"
 )
-
-// drainRetentionSem waits for all slots in the global defaultRetentionSem to
-// become available. This is used in tests to ensure no lingering goroutines
-// from previous tests are holding semaphore slots.
-func drainRetentionSem() {
-	// Wait a bit for any in-flight goroutines to release
-	time.Sleep(100 * time.Millisecond)
-	// Acquire all slots to ensure they're free
-	for i := 0; i < cap(defaultRetentionSem); i++ {
-		select {
-		case defaultRetentionSem <- struct{}{}:
-		default:
-			// Slot was already empty (filled by us in this loop)
-		}
-	}
-	// Release all slots
-	for i := 0; i < cap(defaultRetentionSem); i++ {
-		select {
-		case <-defaultRetentionSem:
-		default:
-		}
-	}
-}
 
 // fakeORASRepo is an in-memory OCI repository used by unit tests.
 //

--- a/internal/backend/remote-state/oras/zot_test.go
+++ b/internal/backend/remote-state/oras/zot_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmvarela/ghoten/internal/configs"
 	"github.com/vmvarela/ghoten/internal/encryption"
 	"github.com/vmvarela/ghoten/internal/states"
+	"github.com/vmvarela/ghoten/internal/states/remote"
 	"github.com/vmvarela/ghoten/internal/states/statemgr"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -370,9 +371,14 @@ func TestZotIntegration_Retention(t *testing.T) {
 		}
 	}
 
-	// Allow async retention goroutines to finish.
-	drainRetentionSem()
-	time.Sleep(500 * time.Millisecond)
+	// Wait for all async retention goroutines to complete before counting tags.
+	// This replaces the previous drainRetentionSem() + time.Sleep(500ms) approach
+	// with a deterministic synchronisation guarantee (issue #58 fix).
+	if rs, ok := sm.(*remote.State); ok {
+		if rc, ok := rs.Client.(*RemoteClient); ok {
+			rc.WaitForRetention()
+		}
+	}
 
 	// Count version tags on the live registry.
 	versionTags := countZotVersionTags(t, addr, "ghoten-test/retention", stateTagPrefix+"default"+stateVersionTagSeparator)

--- a/internal/states/remote/remote.go
+++ b/internal/states/remote/remote.go
@@ -43,6 +43,19 @@ type OptionalClientLocker interface {
 	IsLockingEnabled() bool
 }
 
+// ClientRetentionWaiter is an optional interface for remote state clients that
+// perform async background work after Put (e.g., version-tag pruning). When a
+// client implements this interface, callers must invoke WaitForRetention before
+// the process exits to ensure all background work completes.
+//
+// Pre:  true
+// Post: ∀ goroutine G launched by a prior Put call: G has returned
+//
+//	∧ N(v : v ∈ versionTags : true) ≤ maxVersions  (backend-specific)
+type ClientRetentionWaiter interface {
+	WaitForRetention()
+}
+
 // Payload is the return value from the remote state storage.
 type Payload struct {
 	MD5  []byte

--- a/internal/states/remote/remote_test.go
+++ b/internal/states/remote/remote_test.go
@@ -134,3 +134,51 @@ func (c *mockClientForcePusher) appendLog(method string, content []byte) {
 	}
 	c.log = append(c.log, mockClientRequest{method, contentVal})
 }
+
+// ─── ClientRetentionWaiter tests ──────────────────────────────────────────────
+
+// mockRetentionWaiterClient implements Client and ClientRetentionWaiter.
+// It records whether WaitForRetention was called so tests can assert on it.
+//
+// Pre:  true
+// Post: waited == true iff WaitForRetention() was called at least once
+type mockRetentionWaiterClient struct {
+	nilClient
+	waited bool
+}
+
+func (c *mockRetentionWaiterClient) WaitForRetention() {
+	c.waited = true
+}
+
+// TestState_WaitForRetention_DelegatesToClient verifies that
+// remote.State.WaitForRetention() delegates to the underlying Client when
+// the client implements ClientRetentionWaiter.
+//
+// Pre:  State.Client implements ClientRetentionWaiter
+// Post: Client.WaitForRetention() is called exactly once
+func TestState_WaitForRetention_DelegatesToClient(t *testing.T) {
+	mc := &mockRetentionWaiterClient{}
+	s := &State{Client: mc}
+
+	s.WaitForRetention()
+
+	// Post: delegation occurred
+	if !mc.waited {
+		t.Fatal("WaitForRetention: expected delegation to client, but client.WaitForRetention was not called")
+	}
+}
+
+// TestState_WaitForRetention_NoopWhenClientDoesNotSupport verifies that
+// remote.State.WaitForRetention() is a no-op and does not panic when the
+// client does not implement ClientRetentionWaiter.
+//
+// Pre:  State.Client does NOT implement ClientRetentionWaiter
+// Post: WaitForRetention() returns without error or panic
+func TestState_WaitForRetention_NoopWhenClientDoesNotSupport(t *testing.T) {
+	// nilClient does not implement ClientRetentionWaiter.
+	s := &State{Client: nilClient{}}
+
+	// Must not panic.
+	s.WaitForRetention()
+}

--- a/internal/states/remote/state.go
+++ b/internal/states/remote/state.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/vmvarela/ghoten/internal/backend/local"
 	"github.com/vmvarela/ghoten/internal/encryption"
+	"github.com/vmvarela/ghoten/internal/ghoten"
 	"github.com/vmvarela/ghoten/internal/states"
 	"github.com/vmvarela/ghoten/internal/states/statefile"
 	"github.com/vmvarela/ghoten/internal/states/statemgr"
-	"github.com/vmvarela/ghoten/internal/ghoten"
 )
 
 // State implements the State interfaces in the state package to handle
@@ -327,5 +327,24 @@ func (s *State) StateSnapshotMeta() statemgr.SnapshotMeta {
 	return statemgr.SnapshotMeta{
 		Lineage: s.lineage,
 		Serial:  s.serial,
+	}
+}
+
+// WaitForRetention blocks until all in-flight async background work launched
+// by the underlying Client's Put calls has completed. This is a no-op when
+// the client does not implement ClientRetentionWaiter.
+//
+// Pre:  true
+// Post: Client implements ClientRetentionWaiter →
+//
+//	  ∀ goroutine G launched by a prior Put: G has returned
+//	¬(Client implements ClientRetentionWaiter) → skip
+//
+// Call this after the final PersistState/WriteAndPersist of an operation and
+// before the process can exit, to guarantee version-tag pruning completes
+// (fixes the CLI exit race described in GitHub issue #58).
+func (s *State) WaitForRetention() {
+	if c, ok := s.Client.(ClientRetentionWaiter); ok {
+		c.WaitForRetention()
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #58 — async retention goroutines in \`put()\` were fire-and-forget, allowing \`os.Exit\` to kill the process before version-tag pruning completed, leaving more tags in the OCI registry than \`max_versions\` allows.

Reported by a user running the ORAS backend against a **Gitea** registry with \`max_versions = 10\`, observing 21 versions accumulated in the repository. The root cause was confirmed via code review: \`Put()\` returns immediately after spawning the retention goroutine, and no lifecycle hook waited for it before process exit.

## Changes

### `internal/backend/remote-state/oras/`

- **`client.go`**: Add \`retentionWg sync.WaitGroup\` field to \`RemoteClient\` and \`WaitForRetention()\` method that blocks until all in-flight retention goroutines complete. \`Add(1)\` is called on the **calling goroutine** before the \`go\` statement to prevent a race where \`Wait()\` could observe a zero counter between goroutine scheduling and its first instruction.
- **`client.go`**: Instrument the retention goroutine in \`put()\` with \`retentionWg.Add(1)\` before launch and \`defer retentionWg.Done()\` inside.
- **`client_test.go`**: Add 3 regression tests — \`TestRetentionCompleteAfterWait\`, \`TestRetentionRaceWithoutWait\`, \`TestWaitForRetentionIsIdempotent\` — using a \`slowDeleteRepo\` helper that introduces artificial latency to make the race observable without \`time.Sleep\` in the deterministic path.
- **`client_test.go`**: Replace \`drainRetentionSem()\` + polling loops + \`time.Sleep\` in existing retention tests with deterministic \`WaitForRetention()\` calls.
- **`helper_test.go`**: Remove \`drainRetentionSem()\` (no remaining call sites; was the previous polling-based workaround).
- **`zot_test.go`**: Replace \`drainRetentionSem()\` + \`time.Sleep(500ms)\` with \`WaitForRetention()\` via type assertion.

### `internal/states/remote/`

- **`remote.go`**: Add \`ClientRetentionWaiter\` interface (\`WaitForRetention()\`).
- **`state.go`**: Add \`WaitForRetention()\` to \`remote.State\`, delegating to the underlying client when it satisfies \`ClientRetentionWaiter\`; no-op otherwise.
- **`remote_test.go`**: Add two regression tests — delegate and no-op cases.

### `internal/backend/local/`

- **`backend_apply.go`**: Call \`WaitForRetention()\` via inline interface assertion after \`WriteAndPersist\` in \`opApply\`, matching the existing idiom used for \`statemgr.PersistentMeta\` in \`backend_local.go\`.
- **`backend_refresh.go`**: Same call after \`WriteAndPersist\` in \`opRefresh\`.

## How GHCR deletion works (relevant context)

GHCR returns **HTTP 405** on the standard OCI \`DELETE /v2/.../manifests/<digest>\` endpoint. The existing \`deleteDigestWithFallback()\` already handles this via a cascading strategy:

1. Try standard OCI \`DELETE\` first.
2. On 405, fall back to the **GitHub Packages REST API** (\`DELETE /orgs/{owner}/packages/container/{pkg}/versions/{id}\`) implemented in \`github.go\`.

This fix does not change the deletion logic — it only ensures the goroutines running that logic have time to complete before the process exits.

## Testing

```
go test ./internal/backend/remote-state/oras/... -race -count=1   # PASS
go test ./internal/states/remote/... -race -count=1               # PASS
go test ./internal/backend/local/... -race -count=1               # PASS
TF_ORAS_ZOT_TEST=1 go test ./internal/backend/remote-state/oras/... -run TestZot -v -count=1  # PASS (all 6 Zot integration tests)
```

No \`time.Sleep\` or polling in any deterministic test path. Race detector enabled throughout.