### PR TITLE
fix: limit state read size with io.LimitReader to prevent OOM

### DIFF
--- a/internal/backend/remote-state/oras/backend.go
+++ b/internal/backend/remote-state/oras/backend.go
@@ -44,6 +44,7 @@ const (
 	envVarLockTTL      = "TF_BACKEND_ORAS_LOCK_TTL"
 	envVarRateLimit    = "TF_BACKEND_ORAS_RATE_LIMIT"
 	envVarRateBurst    = "TF_BACKEND_ORAS_RATE_LIMIT_BURST"
+	envVarMaxStateSize = "TF_BACKEND_ORAS_MAX_STATE_SIZE"
 )
 
 // Backend implements the Openghoten backend interface for OCI registries
@@ -53,14 +54,15 @@ type Backend struct {
 	*schema.Backend
 	encryption encryption.StateEncryption
 
-	repository  string
-	insecure    bool
-	caFile      string
-	compression string
-	lockTTL     time.Duration
-	rateLimit   int
-	rateBurst   int
-	retryCfg    RetryConfig
+	repository   string
+	insecure     bool
+	caFile       string
+	compression  string
+	lockTTL      time.Duration
+	rateLimit    int
+	rateBurst    int
+	retryCfg     RetryConfig
+	stateMaxSize int64
 
 	versioningMaxVersions int
 
@@ -136,6 +138,12 @@ func New(enc encryption.StateEncryption) backend.Backend {
 				Optional:    true,
 				Default:     0,
 				Description: "Maximum number of historical state versions to retain. 0 disables versioning, >0 enables versioning with that retention limit.",
+			},
+			"max_state_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc(envVarMaxStateSize, 0),
+				Description: "Maximum state size in bytes that may be read from the registry. Defaults to 268435456 (256 MiB). Set to 0 to use the default. Can also be set via TF_BACKEND_ORAS_MAX_STATE_SIZE env var.",
 			},
 		},
 	}
@@ -220,6 +228,13 @@ func (b *Backend) configure(ctx context.Context) error {
 		b.versioningMaxVersions = 0
 	}
 
+	// State read size limit: 0 means use the built-in default (256 MiB).
+	maxStateSize := data.Get("max_state_size").(int)
+	if maxStateSize < 0 {
+		return fmt.Errorf("max_state_size must be non-negative")
+	}
+	b.stateMaxSize = int64(maxStateSize)
+
 	cfg, diags := cliconfig.LoadConfig(ctx)
 	if diags.HasErrors() {
 		return diags.Err()
@@ -250,6 +265,7 @@ func (b *Backend) StateMgr(ctx context.Context, workspace string) (statemgr.Full
 	client.retryConfig = b.retryCfg
 	client.versioningMaxVersions = b.versioningMaxVersions
 	client.stateCompression = b.compression
+	client.stateMaxSize = b.stateMaxSize
 	client.lockTTL = b.lockTTL
 
 	// NOTE: Background lock cleaner is intentionally not started here to avoid

--- a/internal/backend/remote-state/oras/client.go
+++ b/internal/backend/remote-state/oras/client.go
@@ -45,6 +45,11 @@ const (
 	annotationLockGen      = "org.terraform.lock.generation"
 )
 
+// defaultMaxStateSize is the default upper bound on state data read from the
+// registry. It guards against OOM caused by a maliciously large or corrupted
+// OCI layer (256 MiB).
+const defaultMaxStateSize int64 = 256 * 1024 * 1024
+
 // Tag naming scheme:
 //   - State is stored at "state-<workspaceTag>".
 //   - Lock is stored at "locked-<workspaceTag>".
@@ -206,6 +211,7 @@ type RemoteClient struct {
 	unlockedTag      string
 	retryConfig      RetryConfig
 	stateCompression string
+	stateMaxSize     int64 // max bytes to read from a state layer; 0 means use defaultMaxStateSize
 	lockTTL          time.Duration
 	now              func() time.Time
 
@@ -343,9 +349,19 @@ func (c *RemoteClient) get(ctx context.Context) (*remote.Payload, error) {
 		return nil, fmt.Errorf("unsupported state layer media type %q", layer.MediaType)
 	}
 
-	data, err := io.ReadAll(r)
+	limit := c.stateMaxSize
+	if limit <= 0 {
+		limit = defaultMaxStateSize
+	}
+	// Read at most limit+1 bytes so we can distinguish "exactly at limit" from
+	// "exceeded limit" without allocating the full oversized buffer.
+	lr := io.LimitReader(r, limit+1)
+	data, err := io.ReadAll(lr)
 	if err != nil {
 		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("state size exceeds maximum allowed size of %d bytes; use the max_state_size backend attribute to increase the limit", limit)
 	}
 
 	// MD5 is required by remote.Payload for ETag-like change detection, not for security.

--- a/internal/backend/remote-state/oras/client_test.go
+++ b/internal/backend/remote-state/oras/client_test.go
@@ -1320,6 +1320,101 @@ func TestWaitForRetentionIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestRemoteClient_Get_RejectsOversizedState(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		limit     int64 // stateMaxSize on the client; 0 means use default
+		stateSize int   // bytes to store
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:      "within custom limit",
+			limit:     100,
+			stateSize: 50,
+			wantErr:   false,
+		},
+		{
+			name:      "exactly at custom limit",
+			limit:     100,
+			stateSize: 100,
+			wantErr:   false,
+		},
+		{
+			name:      "exceeds custom limit by one byte",
+			limit:     100,
+			stateSize: 101,
+			wantErr:   true,
+			errSubstr: "state size exceeds maximum",
+		},
+		{
+			name:      "far exceeds custom limit",
+			limit:     10,
+			stateSize: 1000,
+			wantErr:   true,
+			errSubstr: "max_state_size",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newFakeORASRepo()
+			repo := &orasRepositoryClient{inner: fake}
+
+			// Writer uses no limit — we want to store the oversized blob.
+			writer := newRemoteClient(repo, "default")
+			if err := writer.Put(ctx, bytes.Repeat([]byte("x"), tc.stateSize)); err != nil {
+				t.Fatalf("Put: %v", err)
+			}
+
+			// Reader enforces the configured limit.
+			reader := newRemoteClient(repo, "default")
+			reader.stateMaxSize = tc.limit
+
+			_, err := reader.Get(ctx)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tc.errSubstr != "" && !strings.Contains(err.Error(), tc.errSubstr) {
+					t.Fatalf("expected error containing %q, got: %v", tc.errSubstr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestRemoteClient_Get_RejectsOversizedGzipState(t *testing.T) {
+	ctx := context.Background()
+	fake := newFakeORASRepo()
+	repo := &orasRepositoryClient{inner: fake}
+
+	// Store a gzip-compressed state that decompresses to 200 bytes.
+	writer := newRemoteClient(repo, "default")
+	writer.stateCompression = "gzip"
+	if err := writer.Put(ctx, bytes.Repeat([]byte("z"), 200)); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	// Reader allows only 100 bytes (after decompression).
+	reader := newRemoteClient(repo, "default")
+	reader.stateMaxSize = 100
+
+	_, err := reader.Get(ctx)
+	if err == nil {
+		t.Fatal("expected error for oversized gzip state, got nil")
+	}
+	if !strings.Contains(err.Error(), "state size exceeds maximum") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 // ─── Test helpers ────────────────────────────────────────────────────────────
 
 // slowDeleteRepo wraps an inner repository and introduces a configurable delay


### PR DESCRIPTION
## Summary

- Wraps `io.ReadAll(r)` in `RemoteClient.get()` with `io.LimitReader` to prevent OOM from a maliciously large or corrupted OCI layer
- Default limit is 256 MiB (`defaultMaxStateSize` constant in `client.go`)
- Limit applies **after** gzip decompression — it bounds the actual in-memory state size
- Returns a clear, actionable error message when the limit is exceeded

## Configuration

| Method | Key / Variable | Type | Default |
|--------|---------------|------|---------|
| Backend attribute | `max_state_size` | int (bytes) | 0 → 256 MiB |
| Environment variable | `TF_BACKEND_ORAS_MAX_STATE_SIZE` | int (bytes) | 0 → 256 MiB |

A value of `0` means "use the built-in default".

## Tests added

- `TestRemoteClient_Get_RejectsOversizedState` — table-driven: within limit, exactly at limit, one byte over, far over
- `TestRemoteClient_Get_RejectsOversizedGzipState` — verifies the limit applies to the decompressed size

Closes #44