### PR TITLE
ci: add cosign keyless signing and SLSA provenance to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,6 +164,11 @@ jobs:
     name: Aggregate & Upload Assets
     runs-on: ubuntu-latest
     needs: [validate, build]
+    permissions:
+      contents: write
+      id-token: write  # needed for keyless cosign signing
+    outputs:
+      hashes: ${{ steps.hashes.outputs.hashes }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -178,11 +183,34 @@ jobs:
           merge-multiple: true
 
       - name: Generate checksums
+        id: hashes
         working-directory: dist
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
           shasum -a 256 ghoten_${VERSION}_*.tar.gz ghoten_${VERSION}_*.zip \
             > "ghoten_${VERSION}_SHA256SUMS"
+          # Expose base64-encoded hashes for the SLSA provenance generator.
+          echo "hashes=$(cat ghoten_${VERSION}_SHA256SUMS | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        if: needs.validate.outputs.is_release == 'true'
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign archives and checksums (keyless)
+        if: needs.validate.outputs.is_release == 'true'
+        working-directory: dist
+        env:
+          COSIGN_YES: "true"
+        run: |
+          VERSION="${{ needs.validate.outputs.version }}"
+          # Sign every archive and the checksum file; cosign writes
+          # <file>.sig and <file>.pem (certificate) alongside each artifact.
+          for f in ghoten_${VERSION}_*.tar.gz ghoten_${VERSION}_*.zip ghoten_${VERSION}_SHA256SUMS; do
+            cosign sign-blob \
+              --output-signature "${f}.sig" \
+              --output-certificate "${f}.pem" \
+              "${f}"
+          done
 
       - name: Upload assets to release
         if: needs.validate.outputs.is_release == 'true'
@@ -200,7 +228,22 @@ jobs:
           path: dist/
           retention-days: 5
 
-
+  # ---------------------------------------------------------------------------
+  # SLSA provenance — generic SLSA3 provenance for all release artifacts
+  # ---------------------------------------------------------------------------
+  slsa:
+    name: SLSA Provenance
+    needs: [validate, aggregate]
+    if: needs.validate.outputs.is_release == 'true'
+    permissions:
+      actions: read    # To read the workflow path.
+      id-token: write  # To sign the provenance.
+      contents: write  # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: "${{ needs.aggregate.outputs.hashes }}"
+      upload-assets: true
+      upload-tag-name: "${{ needs.validate.outputs.tag }}"
 
   # ---------------------------------------------------------------------------
   # Docker — multi-arch images (only for real releases)
@@ -210,6 +253,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate, build]
     if: needs.validate.outputs.is_release == 'true'
+    permissions:
+      contents: read
+      packages: write
+      id-token: write  # needed for keyless cosign signing
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -267,6 +314,7 @@ jobs:
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Build & push full images
+        id: docker-full
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -285,6 +333,7 @@ jobs:
             org.opencontainers.image.version=${{ needs.validate.outputs.version }}
 
       - name: Build & push minimal images
+        id: docker-minimal
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -301,6 +350,23 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.licenses=MPL-2.0
             org.opencontainers.image.version=${{ needs.validate.outputs.version }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign full Docker images (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign \
+            "ghcr.io/${{ github.repository }}@${{ steps.docker-full.outputs.digest }}"
+
+      - name: Sign minimal Docker images (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign \
+            "ghcr.io/${{ github.repository }}@${{ steps.docker-minimal.outputs.digest }}"
 
   # ---------------------------------------------------------------------------
   # Floating version tags — enables vmvarela/ghoten@v1 and @v1.12
@@ -342,3 +408,4 @@ jobs:
           git tag -fa "$MINOR" -m "Release ${TAG}" "$TAG"
           git push -f origin "$MINOR"
           echo "✅ Updated ${MINOR} → ${TAG}"
+


### PR DESCRIPTION
## Summary

- Signs all binary archives (`.tar.gz`, `.zip`) and `SHA256SUMS` with **keyless cosign** via GitHub OIDC — uploads `.sig` and `.pem` alongside each asset
- Signs Docker images (full and minimal) by digest after push
- Generates **SLSA Level 3 provenance** via `slsa-framework/slsa-github-generator` generic workflow and uploads the `.intoto.jsonl` attestation to the GitHub release

## What changed

| Job | Change |
|-----|--------|
| `aggregate` | Added `id-token: write`, `hashes` output, `cosign-installer`, sign-blob loop, `.sig`/`.pem` upload |
| `docker` | Added `id-token: write`, captured image digests from build steps, `cosign sign` by digest |
| `slsa` (new) | Calls `generator_generic_slsa3.yml@v2.1.0` with base64-encoded hashes from `aggregate` |

## Verification (once merged and a release is published)

```bash
# Verify a binary archive
cosign verify-blob \
  --signature ghoten_1.0.0_linux_amd64.tar.gz.sig \
  --certificate ghoten_1.0.0_linux_amd64.tar.gz.pem \
  --certificate-identity-regexp "https://github.com/vmvarela/ghoten" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  ghoten_1.0.0_linux_amd64.tar.gz

# Verify SLSA provenance
slsa-verifier verify-artifact ghoten_1.0.0_linux_amd64.tar.gz \
  --provenance-path ghoten_1.0.0_linux_amd64.tar.gz.intoto.jsonl \
  --source-uri github.com/vmvarela/ghoten

# Verify a Docker image
cosign verify \
  --certificate-identity-regexp "https://github.com/vmvarela/ghoten" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  ghcr.io/vmvarela/ghoten:1.0.0
```

Closes #36