### PR TITLE
refactor: propagate stopCtx in local backend state persistence

### DIFF
--- a/internal/backend/local/backend_apply.go
+++ b/internal/backend/local/backend_apply.go
@@ -289,7 +289,7 @@ func (b *Local) opApply(
 
 	// Store the final state
 	runningOp.State = applyState
-	err := statemgr.WriteAndPersist(context.TODO(), opState, applyState, schemas)
+	err := statemgr.WriteAndPersist(stopCtx, opState, applyState, schemas)
 	if err != nil {
 		// Export the state file from the state manager and assign the new
 		// state. This is needed to preserve the existing serial and lineage.

--- a/internal/backend/local/backend_refresh.go
+++ b/internal/backend/local/backend_refresh.go
@@ -119,7 +119,7 @@ func (b *Local) opRefresh(
 		return
 	}
 
-	err := statemgr.WriteAndPersist(context.TODO(), opState, newState, schemas)
+	err := statemgr.WriteAndPersist(stopCtx, opState, newState, schemas)
 	if err != nil {
 		diags = diags.Append(fmt.Errorf("failed to write state: %w", err))
 		op.ReportResult(runningOp, diags)


### PR DESCRIPTION
## Summary

- Replace `context.TODO()` with `stopCtx` in `statemgr.WriteAndPersist` calls inside `opRefresh` (`backend_refresh.go:122`) and `opApply` (`backend_apply.go:292`)
- Both functions already receive `stopCtx context.Context` — this is a drop-in replacement with no API surface changes
- Part of the broader context propagation effort tracked in #47

## Changes

- `internal/backend/local/backend_refresh.go`: `context.TODO()` → `stopCtx` at line 122
- `internal/backend/local/backend_apply.go`: `context.TODO()` → `stopCtx` at line 292

## Testing

- `go test -race -count=1 -timeout 30m ./internal/backend/local/...` — passes
- `make golangci-lint` — 0 issues

Closes #74