### PR TITLE
fix(action): auto-create workspace via 'workspace select -or-create'

### DIFF
--- a/action/init.sh
+++ b/action/init.sh
@@ -8,11 +8,7 @@ cd "${GITHUB_WORKSPACE}/${INPUT_WORKING_DIRECTORY}"
 echo "TF_IN_AUTOMATION=true" >> "$GITHUB_ENV"
 export TF_IN_AUTOMATION=true
 
-# Workspace
-if [[ -n "${INPUT_WORKSPACE}" && "${INPUT_WORKSPACE}" != "default" ]]; then
-  echo "TF_WORKSPACE=${INPUT_WORKSPACE}" >> "$GITHUB_ENV"
-  export TF_WORKSPACE="${INPUT_WORKSPACE}"
-fi
+# Workspace — resolved after init (see below)
 
 # Backend repository — auto-compute if not set
 BACKEND_REPO="${INPUT_BACKEND_REPOSITORY:-}"
@@ -81,3 +77,17 @@ if [[ $INIT_EXIT -ne 0 ]]; then
 fi
 
 echo "✅ Initialization complete"
+
+# ─── Workspace select / create ────────────────────────────────────────────────
+# Run workspace select BEFORE exporting TF_WORKSPACE; otherwise ghoten itself
+# would fail with "currently selected workspace does not exist" when resolving
+# the backend state for the workspace command.
+if [[ -n "${INPUT_WORKSPACE}" && "${INPUT_WORKSPACE}" != "default" ]]; then
+  echo "::group::🗂️ Selecting workspace '${INPUT_WORKSPACE}'"
+  ghoten workspace select -or-create "${INPUT_WORKSPACE}"
+  echo "::endgroup::"
+
+  # Now safe to export — workspace is guaranteed to exist in the backend
+  echo "TF_WORKSPACE=${INPUT_WORKSPACE}" >> "$GITHUB_ENV"
+  export TF_WORKSPACE="${INPUT_WORKSPACE}"
+fi


### PR DESCRIPTION
## Summary

- Moves `TF_WORKSPACE` export to *after* `ghoten init`, so the workspace command runs without it set
- Runs `ghoten workspace select -or-create <workspace>` after a successful init for any non-default workspace
- Operation is idempotent: if the workspace already exists it is simply selected; if not, it is created

## Problem

Setting `TF_WORKSPACE` before `ghoten init` causes init to fail in non-interactive mode (`-input=false`) when the workspace does not yet exist in the backend:
```
Error: Currently selected workspace "data-sabia" does not exist
```

## Solution

Run `workspace select -or-create` after init (without `TF_WORKSPACE` in the environment), then export it. The workspace is guaranteed to exist for all subsequent steps.

Closes #94