### PR TITLE
fix(console): add -lock and -lock-timeout flags

### DIFF
--- a/internal/command/console.go
+++ b/internal/command/console.go
@@ -14,9 +14,9 @@ import (
 	"github.com/vmvarela/ghoten/internal/addrs"
 	"github.com/vmvarela/ghoten/internal/backend"
 	"github.com/vmvarela/ghoten/internal/command/arguments"
+	"github.com/vmvarela/ghoten/internal/ghoten"
 	"github.com/vmvarela/ghoten/internal/repl"
 	"github.com/vmvarela/ghoten/internal/tfdiags"
-	"github.com/vmvarela/ghoten/internal/ghoten"
 
 	"github.com/mitchellh/cli"
 )
@@ -33,6 +33,8 @@ func (c *ConsoleCommand) Run(args []string) int {
 	args = c.Meta.process(args)
 	cmdFlags := c.Meta.extendedFlagSet("console")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock")
+	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock-timeout")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command line flags: %s\n", err.Error()))
@@ -236,6 +238,12 @@ Options:
   -consolidate-errors    If Ghoten produces any errors, no consolidation
                          will be performed. All locations, for all errors
                          will be listed. Disabled by default
+
+  -lock=false            Don't hold a state lock during the operation. This is
+                         dangerous if others might concurrently run commands
+                         against the same workspace.
+
+  -lock-timeout=0s       Duration to retry a state lock.
 
   -state=path            Legacy option for the local backend only. See the local
                          backend's documentation for more information.

--- a/internal/command/console_test.go
+++ b/internal/command/console_test.go
@@ -20,6 +20,88 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+func TestConsole_lockedState(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("plan"), td)
+	t.Chdir(td)
+
+	unlock, err := testLockState(t, testDataDir, filepath.Join(td, DefaultStateFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	p := planFixtureProvider()
+	ui := cli.NewMockUi()
+	view, done := testView(t)
+	streams, _ := terminal.StreamsForTesting(t)
+	c := &ConsoleCommand{
+		Meta: Meta{
+			WorkingDir:       workdir.NewDir("."),
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+			View:             view,
+			Streams:          streams,
+		},
+	}
+
+	defer testStdinPipe(t, strings.NewReader("1+1\n"))()
+	args := []string{}
+	code := c.Run(args)
+	if code == 0 {
+		t.Fatal("expected error due to locked state, but got exit code 0")
+	}
+
+	output := done(t).Stderr()
+	uiErr := ui.ErrorWriter.String()
+	combined := output + uiErr
+	if !strings.Contains(combined, "lock") {
+		t.Fatalf("command output does not look like a lock error.\nstderr: %q\nui error: %q", output, uiErr)
+	}
+}
+
+func TestConsole_lockedStateWithLockFalse(t *testing.T) {
+	td := t.TempDir()
+	testCopyDir(t, testFixturePath("plan"), td)
+	t.Chdir(td)
+
+	unlock, err := testLockState(t, testDataDir, filepath.Join(td, DefaultStateFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	p := planFixtureProvider()
+	ui := cli.NewMockUi()
+	view, _ := testView(t)
+	streams, _ := terminal.StreamsForTesting(t)
+	c := &ConsoleCommand{
+		Meta: Meta{
+			WorkingDir:       workdir.NewDir("."),
+			testingOverrides: metaOverridesForProvider(p),
+			Ui:               ui,
+			View:             view,
+			Streams:          streams,
+		},
+	}
+
+	var output bytes.Buffer
+	defer testStdinPipe(t, strings.NewReader("1+1\n"))()
+	outCloser := testStdoutCapture(t, &output)
+
+	args := []string{"-lock=false"}
+	code := c.Run(args)
+	outCloser()
+
+	if code != 0 {
+		t.Fatalf("expected success with -lock=false, got exit code %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	if actual := output.String(); actual != "2\n" {
+		t.Fatalf("unexpected output: %q", actual)
+	}
+}
+
 // ConsoleCommand is tested primarily with tests in the "repl" package.
 // It is not tested here because the Console uses a readline-like library
 // that takes over stdin/stdout. It is difficult to test directly. The


### PR DESCRIPTION
## Summary

- Add `-lock` (default `true`) and `-lock-timeout` (default `0s`) flags to `ghoten console`
- When `-lock=false`, the command uses a no-op locker and bypasses state lock acquisition entirely
- Update help text to document both new flags
- Add two tests: locked state fails by default; locked state succeeds with `-lock=false`

## Motivation

Users running `ghoten console` against a workspace locked by another process were blocked indefinitely with no escape hatch. This brings `console` in line with `plan`/`apply`/`apply-destroy` which already support these flags.

## Implementation

Follows the existing pattern: directly bind to `c.Meta.stateLock` and `c.Meta.stateLockTimeout` via `cmdFlags.BoolVar`/`cmdFlags.DurationVar`. The `Operation()` call already reads those fields to create either a real `clistate.Locker` or a `clistate.NoopLocker`.

Closes #55