### PR TITLE
ci: add test gate to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  test:
+    name: Test
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Run unit tests
+        run: go test -race -count=1 -timeout 30m ./...
+
   validate:
     name: Validate
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
@@ -74,7 +90,7 @@ jobs:
   build:
     name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
     runs-on: ubuntu-latest
-    needs: validate
+    needs: [validate, test]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Add a `test` job to `release.yaml` that runs `go test -race -count=1 -timeout 30m ./...`
- The job runs only for `release` and `workflow_dispatch` events (same condition as `validate`), in parallel with it
- The `build` matrix now depends on both `validate` and `test`, blocking all 17 platform builds until the test suite passes

## Motivation

The release workflow previously built and published binaries without running the test suite. A broken commit could ship a release with failing tests. This adds ~5-7 minutes to the release pipeline but prevents shipping broken code.

## Job dependency graph

```
release-drafter  (push only)
test  ─┐
        ├─▶ build (17×) ─▶ aggregate ─▶ slsa
validate─┘                           ─▶ update-action-tags
                           docker
```

Closes #41