### PR TITLE
fix(oras): add 30s timeout to credential helper invocations

### DIFF
--- a/internal/backend/remote-state/oras/backend.go
+++ b/internal/backend/remote-state/oras/backend.go
@@ -677,13 +677,24 @@ type dockerCredentialHelperEnv struct{}
 
 var _ ociauthconfig.CredentialsLookupEnvironment = dockerCredentialHelperEnv{}
 
+// credentialHelperTimeout is the maximum time allowed for a credential helper
+// process to respond. A hung helper would otherwise block ghoten indefinitely.
+const credentialHelperTimeout = 30 * time.Second
+
 func (dockerCredentialHelperEnv) QueryDockerCredentialHelper(ctx context.Context, helperName string, serverURL string) (ociauthconfig.DockerCredentialHelperGetResult, error) {
 	exe := "docker-credential-" + helperName
 
-	cmd := exec.CommandContext(ctx, exe, "get")
+	tctx, cancel := context.WithTimeout(ctx, credentialHelperTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(tctx, exe, "get")
 	cmd.Stdin = strings.NewReader(serverURL)
 	stdout, err := cmd.Output()
 	if err != nil {
+		if tctx.Err() == context.DeadlineExceeded {
+			logging.HCLogger().Warn("credential helper timed out", "helper", exe, "timeout", credentialHelperTimeout)
+			return ociauthconfig.DockerCredentialHelperGetResult{}, fmt.Errorf("credential helper %q timed out after %s: %w", exe, credentialHelperTimeout, context.DeadlineExceeded)
+		}
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 			return ociauthconfig.DockerCredentialHelperGetResult{}, ociauthconfig.NewCredentialsNotFoundError(err)

--- a/internal/backend/remote-state/oras/backend_test.go
+++ b/internal/backend/remote-state/oras/backend_test.go
@@ -432,3 +432,54 @@ func (e *blockingLookupEnv) QueryDockerCredentialHelper(ctx context.Context, hel
 	<-e.gate
 	return e.inner.QueryDockerCredentialHelper(ctx, helperName, serverURL)
 }
+
+// slowLookupEnv blocks until its context is cancelled, simulating a hung
+// credential helper process.
+type slowLookupEnv struct{}
+
+func (e *slowLookupEnv) QueryDockerCredentialHelper(ctx context.Context, helperName string, serverURL string) (ociauthconfig.DockerCredentialHelperGetResult, error) {
+	<-ctx.Done()
+	return ociauthconfig.DockerCredentialHelperGetResult{}, ctx.Err()
+}
+
+func TestCachedDockerCredentialHelperEnv_TimeoutErrorUsesShortTTL(t *testing.T) {
+	// Use a very short TTL so that a simulated timeout expires quickly.
+	const shortCacheTTL = time.Minute
+
+	now := time.Now()
+	clock := now
+
+	env := &cachedDockerCredentialHelperEnv{
+		inner: &slowLookupEnv{},
+		ttl:   shortCacheTTL,
+		now:   func() time.Time { return clock },
+	}
+	env.cache = make(map[dockerCredentialHelperCacheKey]dockerCredentialHelperCacheEntry)
+	env.inflight = make(map[dockerCredentialHelperCacheKey]*singleflightCall)
+
+	// Use a context with a very short timeout to simulate the helper hanging.
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := env.QueryDockerCredentialHelper(ctx, "test-helper", "https://example.com")
+	if err == nil {
+		t.Fatal("expected an error from a timed-out credential helper, got nil")
+	}
+
+	// The error must NOT be a CredentialsNotFoundError — it is a context error.
+	if ociauthconfig.IsCredentialsNotFoundError(err) {
+		t.Fatalf("expected a non-not-found error (timeout), got a CredentialsNotFoundError: %v", err)
+	}
+
+	// A timeout error should be cached with errorCacheTTL (10s), not the full TTL.
+	// Advance the clock by errorCacheTTL + 1s and verify the cache entry has expired.
+	clock = now.Add(errorCacheTTL + time.Second)
+
+	inner2 := &countingLookupEnv{err: fmt.Errorf("second call")}
+	env.inner = inner2
+
+	_, _ = env.QueryDockerCredentialHelper(context.Background(), "test-helper", "https://example.com")
+	if got := inner2.Calls(); got != 1 {
+		t.Fatalf("expected cache to have expired after errorCacheTTL, but inner was called %d times (want 1)", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `credentialHelperTimeout = 30 * time.Second` constant to `dockerCredentialHelperEnv.QueryDockerCredentialHelper`
- Wrap `exec.CommandContext` with `context.WithTimeout(ctx, credentialHelperTimeout)` so a hung external helper can no longer block ghoten indefinitely
- Log a warning via `logging.HCLogger().Warn(...)` when the timeout fires, including the helper name and configured duration
- Add `TestCachedDockerCredentialHelperEnv_TimeoutErrorUsesShortTTL` to verify: (1) a hung helper returns an error, (2) the error is not a `CredentialsNotFoundError`, (3) the cache entry expires after `errorCacheTTL` (10s), not the full TTL

## Cache behavior

Timeout errors wrap `context.DeadlineExceeded`, which is not a `CredentialsNotFoundError`. The existing singleflight cache already applies `errorCacheTTL = 10s` for non-not-found errors, so timeout results expire quickly and do not block retries permanently.

Closes #45