### PR TITLE
perf(oras): pool gzip writers, readers, and buffers via sync.Pool

### DIFF
--- a/internal/backend/remote-state/oras/client.go
+++ b/internal/backend/remote-state/oras/client.go
@@ -50,6 +50,41 @@ const (
 // OCI layer (256 MiB).
 const defaultMaxStateSize int64 = 256 * 1024 * 1024
 
+// gzipWriterPool pools gzip.Writer values (created with gzip.BestSpeed) to
+// reduce per-Put allocations when state compression is enabled.
+var gzipWriterPool = sync.Pool{
+	New: func() any {
+		gz, _ := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
+		return gz
+	},
+}
+
+// gzipBufPool pools bytes.Buffer values used as the destination during gzip
+// compression, avoiding a heap allocation per compressed write.
+var gzipBufPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
+// gzipReaderPool pools gzip.Reader values to reduce per-Get allocations when
+// state compression is enabled.  Callers must call Reset before use.
+var gzipReaderPool = sync.Pool{
+	New: func() any {
+		// gzip.NewReader requires a valid header up-front; initialise with a
+		// minimal valid gzip stream so the constructor never returns an error.
+		gz, _ := gzip.NewReader(bytes.NewReader(minimalGzipStream))
+		return gz
+	},
+}
+
+// minimalGzipStream is the smallest valid gzip stream (empty body) used only
+// to pre-warm gzipReaderPool entries without a real source reader.
+var minimalGzipStream = func() []byte {
+	var buf bytes.Buffer
+	gz, _ := gzip.NewWriterLevel(&buf, gzip.BestSpeed)
+	_ = gz.Close()
+	return buf.Bytes()
+}()
+
 // Tag naming scheme:
 //   - State is stored at "state-<workspaceTag>".
 //   - Lock is stored at "locked-<workspaceTag>".
@@ -339,11 +374,15 @@ func (c *RemoteClient) get(ctx context.Context) (*remote.Payload, error) {
 	case mediaTypeStateLayer:
 		// no-op
 	case mediaTypeStateLayerGzip:
-		gz, err := gzip.NewReader(rc)
-		if err != nil {
+		gz := gzipReaderPool.Get().(*gzip.Reader)
+		if err := gz.Reset(rc); err != nil {
+			gzipReaderPool.Put(gz)
 			return nil, err
 		}
-		defer gz.Close()
+		defer func() {
+			gz.Close() //nolint:errcheck
+			gzipReaderPool.Put(gz)
+		}()
 		r = gz
 	default:
 		return nil, fmt.Errorf("unsupported state layer media type %q", layer.MediaType)
@@ -1115,19 +1154,25 @@ func workspaceNameFromTag(ctx context.Context, repo *orasRepositoryClient, state
 }
 
 func compressGzip(data []byte) ([]byte, error) {
-	var buf bytes.Buffer
-	gz, err := gzip.NewWriterLevel(&buf, gzip.BestSpeed)
-	if err != nil {
-		return nil, err
-	}
+	buf := gzipBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer gzipBufPool.Put(buf)
+
+	gz := gzipWriterPool.Get().(*gzip.Writer)
+	gz.Reset(buf)
+	defer gzipWriterPool.Put(gz)
+
 	if _, err := gz.Write(data); err != nil {
-		gz.Close()
+		gz.Close() //nolint:errcheck
 		return nil, err
 	}
 	if err := gz.Close(); err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	// Copy result out of the pooled buffer before returning it to the pool.
+	result := make([]byte, buf.Len())
+	copy(result, buf.Bytes())
+	return result, nil
 }
 
 // Error helpers

--- a/internal/backend/remote-state/oras/client_test.go
+++ b/internal/backend/remote-state/oras/client_test.go
@@ -2,6 +2,7 @@ package oras
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1416,6 +1417,74 @@ func TestRemoteClient_Get_RejectsOversizedGzipState(t *testing.T) {
 }
 
 // ─── Test helpers ────────────────────────────────────────────────────────────
+
+// Benchmark helpers ─────────────────────────────────────────────────────────
+
+// makePayload returns a deterministic pseudo-random byte slice of size n.
+// The content is a repeating pattern so gzip always has something to compress.
+func makePayload(n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = byte(i & 0xFF)
+	}
+	return b
+}
+
+var benchSizes = []struct {
+	name string
+	size int
+}{
+	{"1KB", 1 * 1024},
+	{"100KB", 100 * 1024},
+	{"10MB", 10 * 1024 * 1024},
+}
+
+func BenchmarkCompressGzip(b *testing.B) {
+	for _, tc := range benchSizes {
+		payload := makePayload(tc.size)
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(tc.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				out, err := compressGzip(payload)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = out
+			}
+		})
+	}
+}
+
+func BenchmarkDecompressGzip(b *testing.B) {
+	for _, tc := range benchSizes {
+		payload := makePayload(tc.size)
+		compressed, err := compressGzip(payload)
+		if err != nil {
+			b.Fatalf("compress: %v", err)
+		}
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(tc.size))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				gz := gzipReaderPool.Get().(*gzip.Reader)
+				if err := gz.Reset(bytes.NewReader(compressed)); err != nil {
+					gzipReaderPool.Put(gz)
+					b.Fatal(err)
+				}
+				out, err := io.ReadAll(gz)
+				gz.Close() //nolint:errcheck
+				gzipReaderPool.Put(gz)
+				if err != nil {
+					b.Fatal(err)
+				}
+				_ = out
+			}
+		})
+	}
+}
 
 // slowDeleteRepo wraps an inner repository and introduces a configurable delay
 // on every Delete call, making retention goroutines deterministically in-flight


### PR DESCRIPTION
## Summary

- Use `sync.Pool` for `gzip.Writer` and `bytes.Buffer` in `compressGzip()` → 1 alloc/op across all payload sizes (1 KB, 100 KB, 10 MB)
- Use `sync.Pool` for `gzip.Reader` in the decompression path (`get()` method) with `gz.Reset()` before reuse
- Add `BenchmarkCompressGzip` and `BenchmarkDecompressGzip` covering 1 KB, 100 KB, and 10 MB payloads

## Benchmark results (Apple M4)

```
BenchmarkCompressGzip/1KB     16 µs/op   1 allocs/op
BenchmarkCompressGzip/100KB   83 µs/op   1 allocs/op
BenchmarkCompressGzip/10MB     7 ms/op   1 allocs/op
BenchmarkDecompressGzip/1KB    4 µs/op   5 allocs/op   (dominated by io.ReadAll output buf)
BenchmarkDecompressGzip/100KB 44 µs/op  89 allocs/op   (dominated by io.ReadAll output buf)
BenchmarkDecompressGzip/10MB   3 ms/op 104 allocs/op   (dominated by io.ReadAll output buf)
```

Decompression allocs are dominated by `io.ReadAll` growing the output buffer — that is expected and irreducible without knowing the output size in advance.

## Testing

- All existing tests pass (`-race -count=1`)
- Lint clean (0 issues, linux + windows)

Closes #42