### PR TITLE
chore: remove GODEBUG winsymlink=0 from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ go 1.26
 // In go1.23 the godebug flag for this was named 'tlskyber', renamed in go1.24 to 'tlsmlkem'. https://tip.golang.org/doc/godebug#go-124
 godebug (
 	tlsmlkem=0
-	winsymlink=0 // See https://github.com/opentofu/opentofu/pull/3289
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,7 @@ go 1.26
 // At the time of adding this configuration, the new Go feature introduced here https://github.com/golang/go/issues/67061,
 // was having a good amount of issues linked to, affecting AWS Firewall, GCP various services and a lot more.
 // In go1.23 the godebug flag for this was named 'tlskyber', renamed in go1.24 to 'tlsmlkem'. https://tip.golang.org/doc/godebug#go-124
-godebug (
-	tlsmlkem=0
-)
+godebug tlsmlkem=0
 
 require (
 	cloud.google.com/go/kms v1.26.0


### PR DESCRIPTION
## Summary

- Removes `winsymlink=0` from the `godebug` block in `go.mod`
- Go 1.23+ defaults to `winsymlink=1` (junctions are directories, not symlinks); Go 1.26 deprecates the flag entirely
- Audited all affected code paths (`copy_dir.go`, `filesystem_search.go`, `communicator.go`, `command_test.go`) — they use standard `ModeSymlink`/`os.Readlink` and are unaffected on Linux/macOS

## Behavior change

On Windows, directory junctions will now be traversed as regular directories rather than followed as symlinks. This matches the modern Go default and the upstream opentofu#3415 fix.

## Testing

- Build passes
- `internal/copy` and `internal/getproviders` tests pass with `-race`
- Lint clean (0 issues, linux + windows)

Closes #53