### PR TITLE
chore(docker): run as non-root user and add OCI labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,17 @@ FROM alpine:3.20
 
 ARG TARGETARCH
 
-LABEL maintainer="Ghoten"
+LABEL maintainer="Ghoten" \
+      org.opencontainers.image.licenses="MPL-2.0" \
+      org.opencontainers.image.source="https://github.com/vmvarela/ghoten"
 
-RUN apk add --no-cache git bash openssh
+RUN apk add --no-cache git bash openssh \
+    && addgroup -S ghoten \
+    && adduser -S -G ghoten ghoten
 
 COPY --from=binaries linux/${TARGETARCH}/ghoten /usr/local/bin/ghoten
+
+USER ghoten
 
 ONBUILD RUN echo -e "\033[1;33mWARNING! PLEASE READ!\033[0m" >&2 \
             && echo -e "\033[1;33mPlease read carefully: you are using the Ghoten image as a base image\033[0m" >&2 \

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -7,8 +7,12 @@ FROM scratch
 
 ARG TARGETARCH
 
-LABEL maintainer="Ghoten"
+LABEL maintainer="Ghoten" \
+      org.opencontainers.image.licenses="MPL-2.0" \
+      org.opencontainers.image.source="https://github.com/vmvarela/ghoten"
 
 COPY --from=binaries linux/${TARGETARCH}/ghoten /usr/local/bin/ghoten
+
+USER 65534:65534
 
 ENTRYPOINT ["/usr/local/bin/ghoten"]


### PR DESCRIPTION
## Summary

- `Dockerfile`: creates system user `ghoten` (via `addgroup`/`adduser`) and adds `USER ghoten` — container no longer runs as root
- `Dockerfile.minimal`: adds `USER 65534:65534` (nobody/nogroup) — works in scratch images with no user database
- Both Dockerfiles gain static OCI labels (`org.opencontainers.image.licenses`, `.source`); dynamic per-release labels (`title`, `description`, `version`, `url`) continue to be injected by the release workflow via `docker/build-push-action`

## Testing

No code changes — Dockerfile-only. The binary is statically linked and does not require any user-specific filesystem permissions. Existing CI build and push continues to work unchanged.

Closes #46