### PR TITLE
fix(ghoten): propagate context in state transforms and provider calls

### DIFF
--- a/internal/ghoten/node_resource_abstract.go
+++ b/internal/ghoten/node_resource_abstract.go
@@ -607,6 +607,7 @@ func (n *NodeAbstractResourceInstance) readResourceInstanceState(ctx context.Con
 	// prevAddr will match the newAddr if the resource wasn't moved (prevRunAddr checks move results)
 	prevAddr := n.prevRunAddr(evalCtx)
 	transformArgs := stateTransformArgs{
+		ctx:                  ctx,
 		currentAddr:          addr,
 		prevAddr:             prevAddr,
 		provider:             provider,
@@ -666,6 +667,7 @@ func (n *NodeAbstractResourceInstance) readResourceInstanceStateDeposed(ctx cont
 	// prevAddr will match the newAddr if the resource wasn't moved (prevRunAddr checks move results)
 	prevAddr := n.prevRunAddr(evalCtx)
 	transformArgs := stateTransformArgs{
+		ctx:                  ctx,
 		currentAddr:          addr,
 		prevAddr:             prevAddr,
 		provider:             provider,

--- a/internal/ghoten/upgrade_resource_state.go
+++ b/internal/ghoten/upgrade_resource_state.go
@@ -21,6 +21,8 @@ import (
 
 // stateTransformArgs is a struct for convenience that holds the parameters required for state transformations
 type stateTransformArgs struct {
+	// ctx is the context to propagate to provider calls.
+	ctx context.Context
 	// currentAddr is the current/latest address of the resource
 	currentAddr addrs.AbsResourceInstance
 	// prevAddr is the previous address of the resource
@@ -110,7 +112,7 @@ func upgradeResourceStateTransform(args stateTransformArgs) (cty.Value, []byte, 
 		req.RawStateJSON = args.objectSrc.AttrsJSON
 	}
 
-	resp := args.provider.UpgradeResourceState(context.TODO(), req)
+	resp := args.provider.UpgradeResourceState(args.ctx, req)
 	diags := resp.Diagnostics
 	if diags.HasErrors() {
 		log.Printf("[TRACE] upgradeResourceStateTransform: failed - address: %s", args.currentAddr)
@@ -140,7 +142,7 @@ func moveResourceStateTransform(args stateTransformArgs) (cty.Value, []byte, tfd
 		SourcePrivate:         args.objectSrc.Private,
 		TargetTypeName:        args.currentAddr.Resource.Resource.Type,
 	}
-	resp := args.provider.MoveResourceState(context.TODO(), req)
+	resp := args.provider.MoveResourceState(args.ctx, req)
 	diags := resp.Diagnostics
 	if diags.HasErrors() {
 		log.Printf("[TRACE] moveResourceStateTransform: failed - new address: %s, previous address: %s - diags: %s", args.currentAddr, args.prevAddr, diags.Err().Error())

--- a/internal/ghoten/upgrade_resource_state_test.go
+++ b/internal/ghoten/upgrade_resource_state_test.go
@@ -7,6 +7,7 @@ package ghoten
 
 import (
 	"bytes"
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -180,6 +181,7 @@ func getMoveStateArgs() stateTransformArgs {
 		},
 	}
 	return stateTransformArgs{
+		ctx:         context.Background(),
 		currentAddr: mustResourceInstanceAddr("foo2_instance.cur"),
 		prevAddr:    mustResourceInstanceAddr("foo_instance.prev"),
 		provider: &MockProvider{
@@ -279,6 +281,7 @@ func getUpgradeStateArgs() stateTransformArgs {
 		},
 	}
 	args := stateTransformArgs{
+		ctx:         context.Background(),
 		currentAddr: mustResourceInstanceAddr("foo_instance.cur"),
 		prevAddr:    mustResourceInstanceAddr("foo_instance.cur"),
 		provider: &MockProvider{
@@ -403,6 +406,7 @@ func TestTransformResourceState(t *testing.T) {
 		{
 			name: "flatmap state should be removed after transformation",
 			args: stateTransformArgs{
+				ctx:         context.Background(),
 				currentAddr: mustResourceInstanceAddr("test_instance.foo"),
 				provider: &MockProvider{
 					GetProviderSchemaResponse: testProviderSchema("test"),
@@ -432,6 +436,7 @@ func TestTransformResourceState(t *testing.T) {
 		{
 			name: "state must conform to schema",
 			args: stateTransformArgs{
+				ctx:         context.Background(),
 				currentAddr: mustResourceInstanceAddr("test_instance.foo"),
 				provider: &MockProvider{
 					GetProviderSchemaResponse: testProviderSchema("test"),
@@ -456,6 +461,7 @@ func TestTransformResourceState(t *testing.T) {
 		{
 			name: "non-managed resource should not be upgraded",
 			args: stateTransformArgs{
+				ctx:         context.Background(),
 				currentAddr: getDataResourceModeInstance(),
 				objectSrc: &states.ResourceInstanceObjectSrc{
 					AttrsJSON: []byte(`{"foo":"bar"}`),
@@ -475,6 +481,7 @@ func TestTransformResourceState(t *testing.T) {
 		{
 			name: "private state should be updated",
 			args: stateTransformArgs{
+				ctx:         context.Background(),
 				currentAddr: mustResourceInstanceAddr("test_instance.foo"),
 				provider: &MockProvider{
 					GetProviderSchemaResponse: testProviderSchema("test"),


### PR DESCRIPTION
## Summary

- Adds `ctx context.Context` field to `stateTransformArgs`
- Replaces `context.TODO()` in `upgradeResourceStateTransform` (line 113) and `moveResourceStateTransform` (line 143) with `args.ctx`
- Updates both call sites in `readResourceInstanceState` and `readResourceInstanceStateDeposed` (`node_resource_abstract.go`) to populate `ctx` from the incoming `context.Context` parameter
- Updates test helpers (`getMoveStateArgs`, `getUpgradeStateArgs`) and inline `stateTransformArgs` literals in `TestTransformResourceState` to use `context.Background()`

## Testing

- All `internal/ghoten` tests pass with `-race -count=1`
- Lint clean (0 issues, linux + windows)

Closes #75