### PR TITLE
fix: consistent logging in ORAS backend

### DIFF
--- a/internal/backend/remote-state/oras/backend.go
+++ b/internal/backend/remote-state/oras/backend.go
@@ -457,7 +457,7 @@ func newORASHTTPClient(insecure bool, caFile string, rateLimit int, rateBurst in
 		}
 		t.TLSClientConfig.InsecureSkipVerify = insecure
 		if insecure {
-			logging.HCLogger().Warn("ORAS backend: TLS certificate verification is disabled (insecure=true)")
+			logging.HCLogger().Named("backend.oras").Warn("TLS certificate verification is disabled", "insecure", true)
 		}
 		if caFile != "" {
 			pem, err := os.ReadFile(caFile)

--- a/internal/backend/remote-state/oras/client.go
+++ b/internal/backend/remote-state/oras/client.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/vmvarela/ghoten/internal/logging"
@@ -478,9 +479,10 @@ func (c *RemoteClient) put(ctx context.Context, state []byte) error {
 			defer func() { <-sem }()
 			asyncCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
+			retentionLog := logging.HCLogger().Named("backend.oras")
 			existing, listErr := c.listExistingVersions(asyncCtx)
 			if listErr != nil {
-				logging.HCLogger().Trace("async retention: failed to list versions", "error", listErr.Error())
+				retentionLog.Trace("async retention: failed to list versions", "error", listErr)
 				return
 			}
 			// Ensure the version we just created is included even if the
@@ -496,12 +498,12 @@ func (c *RemoteClient) put(ctx context.Context, state []byte) error {
 				existing = append(existing, nextVersion)
 			}
 			if err := c.enforceVersionRetention(asyncCtx, manifestDesc, existing); err != nil {
-				logging.HCLogger().Trace("async retention cleanup failed", "error", err.Error())
+				retentionLog.Trace("async retention cleanup failed", "error", err)
 			}
 		}()
 	default:
 		// Semaphore full, skip this cleanup (will happen on next Put)
-		logging.HCLogger().Trace("async retention skipped: too many pending cleanups")
+		logging.HCLogger().Named("backend.oras").Trace("async retention skipped: too many pending cleanups")
 	}
 
 	return nil
@@ -639,7 +641,7 @@ func classifyTags(tags []string, deleteSet, keepSet map[string]struct{}) (toDele
 	return
 }
 
-func (c *RemoteClient) retagToNewManifest(ctx context.Context, tags []string, logger interface{ Debug(string, ...interface{}) }) error {
+func (c *RemoteClient) retagToNewManifest(ctx context.Context, tags []string, logger hclog.Logger) error {
 	if len(tags) == 0 {
 		return nil
 	}

--- a/internal/backend/remote-state/oras/client_test.go
+++ b/internal/backend/remote-state/oras/client_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/vmvarela/ghoten/internal/states/statemgr"
@@ -1167,8 +1168,7 @@ func TestRemoteClient_RetagToNewManifest_PreservesVersionAnnotation(t *testing.T
 	}
 
 	// Simulate retagToNewManifest (as done during retention).
-	logger := &noopLogger{}
-	if err := client.retagToNewManifest(ctx, []string{client.versionTagFor(1)}, logger); err != nil {
+	if err := client.retagToNewManifest(ctx, []string{client.versionTagFor(1)}, hclog.NewNullLogger()); err != nil {
 		t.Fatalf("retagToNewManifest: %v", err)
 	}
 
@@ -1508,8 +1508,3 @@ func (r *slowDeleteRepo) Delete(ctx context.Context, target ocispec.Descriptor) 
 	}
 	return r.delegatingRepo.inner.Delete(ctx, target)
 }
-
-// noopLogger satisfies the logger interface used by retagToNewManifest.
-type noopLogger struct{}
-
-func (noopLogger) Debug(string, ...interface{}) {}


### PR DESCRIPTION
## Summary

- Use named logger `backend.oras` consistently in all ORAS retention log calls (replacing bare `logging.HCLogger()` calls)
- Pass `err` directly instead of `err.Error()` in structured log KV pairs (preserves error type for `go-hclog`)
- Widen the logger interface in `retagToNewManifest` from a narrow `Debug`-only interface to `hclog.Logger`
- Add structured KV pairs to the `Warn` call in `backend.go` (insecure TLS warning)
- Update `client_test.go` to use `hclog.NewNullLogger()` instead of the now-removed `noopLogger` stub

## Changes

- `internal/backend/remote-state/oras/client.go` — named logger, `err` in KV pairs, `hclog.Logger` interface
- `internal/backend/remote-state/oras/backend.go` — structured KV pairs on Warn
- `internal/backend/remote-state/oras/client_test.go` — replace `noopLogger` with `hclog.NewNullLogger()`

## Testing

- 100 tests passing (`go test -race -count=1 ./internal/backend/remote-state/oras/...`)
- 0 linter issues (`golangci-lint run ./internal/backend/remote-state/oras/...`)

Closes #48