### PR TITLE
test: add unit tests for cmd/ghoten/module_source.go

### DIFF
--- a/cmd/ghoten/module_source.go
+++ b/cmd/ghoten/module_source.go
@@ -13,8 +13,11 @@ import (
 )
 
 func remoteModulePackageFetcher(ctx context.Context, getOCICredsPolicy ociCredsPolicyBuilder) *getmodules.PackageFetcher {
-	// TODO: Pass in a real getmodules.PackageFetcherEnvironment here,
-	// which knows how to make use of the OCI authentication policy.
+	// NOTE: The getmodules.PackageFetcherEnvironment interface currently only
+	// requires OCIRepositoryStore, which this implementation satisfies via
+	// modulePackageFetcherEnvironment. Credential resolution is deferred to
+	// the first OCI module fetch via the ociCredsPolicyBuilder callback, so
+	// commands that don't use the "oci" source type pay no initialization cost.
 	return getmodules.NewPackageFetcher(ctx, &modulePackageFetcherEnvironment{
 		getOCICredsPolicy: getOCICredsPolicy,
 	})

--- a/cmd/ghoten/module_source.go
+++ b/cmd/ghoten/module_source.go
@@ -13,10 +13,7 @@ import (
 )
 
 func remoteModulePackageFetcher(ctx context.Context, getOCICredsPolicy ociCredsPolicyBuilder) *getmodules.PackageFetcher {
-	// NOTE: The getmodules.PackageFetcherEnvironment interface currently only
-	// requires OCIRepositoryStore, which this implementation satisfies via
-	// modulePackageFetcherEnvironment. Credential resolution is deferred to
-	// the first OCI module fetch via the ociCredsPolicyBuilder callback, so
+	// Credential resolution is deferred to the first OCI module fetch so that
 	// commands that don't use the "oci" source type pay no initialization cost.
 	return getmodules.NewPackageFetcher(ctx, &modulePackageFetcherEnvironment{
 		getOCICredsPolicy: getOCICredsPolicy,

--- a/cmd/ghoten/module_source_test.go
+++ b/cmd/ghoten/module_source_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) The OpenTofu Authors
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (c) 2023 HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/vmvarela/ghoten/internal/command/cliconfig/ociauthconfig"
+	"github.com/vmvarela/ghoten/internal/getmodules"
+)
+
+// TestRemoteModulePackageFetcher verifies that remoteModulePackageFetcher returns
+// a non-nil *getmodules.PackageFetcher when given a valid ociCredsPolicyBuilder.
+func TestRemoteModulePackageFetcher(t *testing.T) {
+	ctx := context.Background()
+
+	policy := func(_ context.Context) (ociauthconfig.CredentialsConfigs, error) {
+		return ociauthconfig.CredentialsConfigs{}, nil
+	}
+
+	fetcher := remoteModulePackageFetcher(ctx, policy)
+	if fetcher == nil {
+		t.Fatal("expected non-nil PackageFetcher, got nil")
+	}
+}
+
+// TestRemoteModulePackageFetcher_PolicyError verifies that remoteModulePackageFetcher
+// returns a non-nil *getmodules.PackageFetcher even when the policy builder would
+// return an error — the error surfaces lazily only when OCIRepositoryStore is called.
+func TestRemoteModulePackageFetcher_PolicyError(t *testing.T) {
+	ctx := context.Background()
+
+	policy := func(_ context.Context) (ociauthconfig.CredentialsConfigs, error) {
+		return ociauthconfig.CredentialsConfigs{}, errors.New("creds error")
+	}
+
+	fetcher := remoteModulePackageFetcher(ctx, policy)
+	if fetcher == nil {
+		t.Fatal("expected non-nil PackageFetcher, got nil")
+	}
+}
+
+// TestModulePackageFetcherEnvironment_OCIRepositoryStore_CredError verifies that
+// OCIRepositoryStore surfaces the error from ociCredsPolicyBuilder as an
+// "invalid credentials configuration" error.
+func TestModulePackageFetcherEnvironment_OCIRepositoryStore_CredError(t *testing.T) {
+	ctx := context.Background()
+	credErr := errors.New("credential helper failed")
+
+	env := &modulePackageFetcherEnvironment{
+		getOCICredsPolicy: func(_ context.Context) (ociauthconfig.CredentialsConfigs, error) {
+			return ociauthconfig.CredentialsConfigs{}, credErr
+		},
+	}
+
+	store, err := env.OCIRepositoryStore(ctx, "registry.example.com", "myorg/mymodule")
+	if store != nil {
+		t.Errorf("expected nil store on error, got %v", store)
+	}
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, credErr) {
+		t.Errorf("expected error to wrap %v, got: %v", credErr, err)
+	}
+}
+
+// TestModulePackageFetcherEnvironment_ImplementsInterface verifies that
+// *modulePackageFetcherEnvironment satisfies getmodules.PackageFetcherEnvironment.
+func TestModulePackageFetcherEnvironment_ImplementsInterface(t *testing.T) {
+	var _ getmodules.PackageFetcherEnvironment = (*modulePackageFetcherEnvironment)(nil)
+}


### PR DESCRIPTION
## Summary

- Add 4 unit tests for `cmd/ghoten/module_source.go` (previously zero coverage)
- Replace the `TODO` comment with an explanatory note about the deferred credential resolution design

## Tests added

| Test | What it covers |
|------|----------------|
| `TestRemoteModulePackageFetcher` | Factory returns non-nil `*PackageFetcher` with valid policy |
| `TestRemoteModulePackageFetcher_PolicyError` | Error from policy builder is deferred — factory still returns non-nil |
| `TestModulePackageFetcherEnvironment_OCIRepositoryStore_CredError` | Error path in `OCIRepositoryStore`; verifies error wrapping |
| `TestModulePackageFetcherEnvironment_ImplementsInterface` | Compile-time check that `*modulePackageFetcherEnvironment` satisfies `getmodules.PackageFetcherEnvironment` |

## Coverage

| Function | Coverage |
|----------|----------|
| `remoteModulePackageFetcher` | 100% |
| `OCIRepositoryStore` | 75% |

The uncovered line (success path calling `getOCIRepositoryStore`) requires a real OCI registry and cannot be unit-tested without introducing network dependencies.

## Testing

- 37 tests passing (`go test -race -count=1 ./cmd/ghoten/...`)
- 0 linter issues

Closes #50