### PR TITLE
fix: prevent crash in test cleanup and assertion evaluation

### DIFF
--- a/internal/command/test.go
+++ b/internal/command/test.go
@@ -28,13 +28,13 @@ import (
 	"github.com/vmvarela/ghoten/internal/command/views"
 	"github.com/vmvarela/ghoten/internal/configs"
 	"github.com/vmvarela/ghoten/internal/encryption"
+	"github.com/vmvarela/ghoten/internal/ghoten"
 	"github.com/vmvarela/ghoten/internal/logging"
 	"github.com/vmvarela/ghoten/internal/moduletest"
 	"github.com/vmvarela/ghoten/internal/plans"
 	"github.com/vmvarela/ghoten/internal/states"
 	"github.com/vmvarela/ghoten/internal/states/statefile"
 	"github.com/vmvarela/ghoten/internal/tfdiags"
-	"github.com/vmvarela/ghoten/internal/ghoten"
 )
 
 const (
@@ -789,6 +789,12 @@ func (runner *TestFileRunner) destroy(ctx context.Context, config *configs.Confi
 	diags = diags.Append(planDiags)
 
 	if diags.HasErrors() {
+		return state, diags
+	}
+
+	if !plan.CanApply() {
+		// The destroy plan is incomplete (e.g. errored during planning).
+		// Attempting to apply it would panic; return the current state as-is.
 		return state, diags
 	}
 

--- a/internal/ghoten/test_context.go
+++ b/internal/ghoten/test_context.go
@@ -148,10 +148,6 @@ func (tc *TestContext) evaluate(state *states.SyncState, changes *plans.ChangesS
 			continue
 		}
 
-		// The condition result may be marked if the expression refers to a
-		// sensitive value.
-		runVal, _ = runVal.Unmark()
-
 		if runVal.IsNull() {
 			run.Status = run.Status.Merge(moduletest.Error)
 			run.Diagnostics = run.Diagnostics.Append(&hcl.Diagnostic{
@@ -191,6 +187,12 @@ func (tc *TestContext) evaluate(state *states.SyncState, changes *plans.ChangesS
 			})
 			continue
 		}
+
+		// The condition result may be marked if the expression refers to a
+		// sensitive value. Unmark after conversion so that marks introduced
+		// by convert.Convert (e.g. from function calls on marked values) are
+		// also removed before calling False(), which panics on marked values.
+		runVal, _ = runVal.Unmark()
 
 		if runVal.False() {
 			run.Status = run.Status.Merge(moduletest.Fail)


### PR DESCRIPTION
## Summary

Two crash scenarios fixed in the test framework.

## Fix 1 — `internal/command/test.go`: unguarded `apply()` in destroy path

The `destroy()` method called `runner.apply()` without checking `plan.CanApply()`. If `tfCtx.Plan()` returns a plan with `Errored: true` (e.g. due to a provider error during planning) but without error diagnostics, the `diags.HasErrors()` guard passes and apply is called with an incomplete plan, causing a panic.

**Fix:** Added a `plan.CanApply()` guard after the diagnostics check, returning the current state as-is if the plan cannot be applied.

## Fix 2 — `internal/ghoten/test_context.go`: marks residuales post-`convert.Convert`

In the assertion evaluation loop, `Unmark()` was called before `convert.Convert()`. `convert.Convert()` can re-introduce marks when evaluating function calls on sensitive values. The subsequent `runVal.False()` call panics via `assertUnmarked()` on any marked value.

**Fix:** Moved `Unmark()` to after `convert.Convert()`, matching the established pattern in `eval_conditions.go`.

## Testing

- 4345 tests passing (`go test -race -count=1 ./internal/command/... ./internal/ghoten/...`)
- 0 linter issues

Closes #83