### PR TITLE
refactor: propagate context in resource planning and import evaluation

### DIFF
--- a/internal/ghoten/eval_context.go
+++ b/internal/ghoten/eval_context.go
@@ -30,6 +30,10 @@ type EvalContext interface {
 	// via ghoten.Context.Stop()
 	Stopped() <-chan struct{}
 
+	// Context returns the context.Context for the current operation.
+	// It is cancelled when the operation is stopped via ghoten.Context.Stop().
+	Context() context.Context
+
 	// Path is the current module path.
 	Path() addrs.ModuleInstance
 

--- a/internal/ghoten/eval_context_builtin.go
+++ b/internal/ghoten/eval_context_builtin.go
@@ -98,6 +98,13 @@ func (c *BuiltinEvalContext) Stopped() <-chan struct{} {
 	return c.StopContext.Done()
 }
 
+func (c *BuiltinEvalContext) Context() context.Context {
+	if c.StopContext == nil {
+		return context.Background()
+	}
+	return c.StopContext
+}
+
 func (c *BuiltinEvalContext) Hook(fn func(Hook) (HookAction, error)) error {
 	for _, h := range c.Hooks {
 		action, err := fn(h)

--- a/internal/ghoten/eval_context_mock.go
+++ b/internal/ghoten/eval_context_mock.go
@@ -32,6 +32,7 @@ import (
 type MockEvalContext struct {
 	StoppedCalled bool
 	StoppedValue  <-chan struct{}
+	ContextValue  context.Context
 
 	HookCalled bool
 	HookHook   Hook
@@ -136,6 +137,13 @@ var _ EvalContext = (*MockEvalContext)(nil)
 func (c *MockEvalContext) Stopped() <-chan struct{} {
 	c.StoppedCalled = true
 	return c.StoppedValue
+}
+
+func (c *MockEvalContext) Context() context.Context {
+	if c.ContextValue != nil {
+		return c.ContextValue
+	}
+	return context.Background()
 }
 
 func (c *MockEvalContext) Hook(fn func(Hook) (HookAction, error)) error {

--- a/internal/ghoten/eval_import.go
+++ b/internal/ghoten/eval_import.go
@@ -46,7 +46,7 @@ func evaluateImportIdExpressionInner(expr hcl.Expression, evalCtx EvalContext, k
 	}
 
 	// evaluate the import ID and take into consideration the for_each key (if exists)
-	importIdVal, evalDiags := evaluateExprWithRepetitionData(context.TODO(), evalCtx, expr, cty.String, keyData)
+	importIdVal, evalDiags := evaluateExprWithRepetitionData(evalCtx.Context(), evalCtx, expr, cty.String, keyData)
 	diags = diags.Append(evalDiags)
 
 	if diags.HasErrors() {
@@ -175,7 +175,7 @@ func parseImportIndexKeyExpr(evalCtx EvalContext, expr hcl.Expression, keyData i
 	}
 
 	// evaluate and take into consideration the for_each key (if exists)
-	val, diags := evaluateExprWithRepetitionData(context.TODO(), evalCtx, expr, cty.DynamicPseudoType, keyData)
+	val, diags := evaluateExprWithRepetitionData(evalCtx.Context(), evalCtx, expr, cty.DynamicPseudoType, keyData)
 	if diags.HasErrors() {
 		return idx, diags
 	}

--- a/internal/ghoten/node_resource_plan.go
+++ b/internal/ghoten/node_resource_plan.go
@@ -178,7 +178,7 @@ func (n *nodeExpandPlannableResource) DynamicExpand(evalCtx EvalContext) (*Graph
 		// If we have import from import block and PreDestroyRefresh is true, we know we are running as part of a refresh plan, immediately before a destroy
 		// plan. In the destroy plan mode, import blocks are not relevant, that's why we skip resolving imports
 		if importTarget.IsFromImportBlock() && !n.preDestroyRefresh {
-			err := importResolver.ExpandAndResolveImport(context.TODO(), importTarget, evalCtx)
+			err := importResolver.ExpandAndResolveImport(evalCtx.Context(), importTarget, evalCtx)
 			diags = diags.Append(err)
 		}
 	}
@@ -193,7 +193,7 @@ func (n *nodeExpandPlannableResource) DynamicExpand(evalCtx EvalContext) (*Graph
 	instAddrs := addrs.MakeSet[addrs.Checkable]()
 	for _, module := range moduleInstances {
 		resAddr := n.Addr.Resource.Absolute(module)
-		err := n.expandResourceInstances(context.TODO(), evalCtx, resAddr, &g, instAddrs)
+		err := n.expandResourceInstances(evalCtx.Context(), evalCtx, resAddr, &g, instAddrs)
 		diags = diags.Append(err)
 	}
 	if diags.HasErrors() {


### PR DESCRIPTION
## Summary

Part of #47 (context propagation series).

Replaces 4 `context.TODO()` usages in the resource planning and import evaluation paths by adding a `Context() context.Context` accessor to the `EvalContext` interface.

## Approach

`DynamicExpand(EvalContext)` cannot accept a `context.Context` parameter directly without changing the `GraphNodeDynamicExpandable` interface (which would touch 7 implementations and the graph walker). Instead, we expose the already-existing `StopContext` field of `BuiltinEvalContext` through the interface — it is the correct lifecycle context for the operation and is cancelled when `ghoten.Context.Stop()` is called.

## Changes

| File | Change |
|------|--------|
| `internal/ghoten/eval_context.go` | Add `Context() context.Context` to `EvalContext` interface |
| `internal/ghoten/eval_context_builtin.go` | Implement `Context()` returning `StopContext` (falls back to `context.Background()` when nil, consistent with `Stopped()`) |
| `internal/ghoten/eval_context_mock.go` | Add `ContextValue` field + `Context()` implementation for tests |
| `internal/ghoten/eval_import.go` | Replace `context.TODO()` at lines 49, 178 with `evalCtx.Context()` |
| `internal/ghoten/node_resource_plan.go` | Replace `context.TODO()` at lines 181, 196 with `evalCtx.Context()` |

## Testing

- 1621 tests passing (`go test -race -count=1 -timeout 30m ./internal/ghoten/...`)
- 0 linter issues

Closes #76