### PR TITLE
test(oras): edge case tests — TLS, Put, manifest, cancellation (#51)

### DIFF
--- a/internal/backend/remote-state/oras/backend_test.go
+++ b/internal/backend/remote-state/oras/backend_test.go
@@ -2,9 +2,14 @@ package oras
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -482,4 +487,104 @@ func TestCachedDockerCredentialHelperEnv_TimeoutErrorUsesShortTTL(t *testing.T) 
 	if got := inner2.Calls(); got != 1 {
 		t.Fatalf("expected cache to have expired after errorCacheTTL, but inner was called %d times (want 1)", got)
 	}
+}
+
+// writeTempFile writes data to a new file in t.TempDir() and returns the path.
+func writeTempFile(t *testing.T, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("writing temp file %s: %v", path, err)
+	}
+	return path
+}
+
+// TestNewORASHTTPClient covers the TLS configuration paths of newORASHTTPClient.
+// The insecure and CA-file subtests use a real httptest.TLSServer to verify
+// behaviour end-to-end rather than inspecting the (unstable) transport chain.
+func TestNewORASHTTPClient(t *testing.T) {
+	t.Run("default — no TLS options", func(t *testing.T) {
+		client, err := newORASHTTPClient(false, "", 0, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+	})
+
+	t.Run("insecure=true succeeds against self-signed TLS server", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		client, err := newORASHTTPClient(true, "", 0, 0)
+		if err != nil {
+			t.Fatalf("unexpected error building client: %v", err)
+		}
+
+		resp, err := client.Get(srv.URL) //nolint:noctx
+		if err != nil {
+			t.Fatalf("GET to TLS server with insecure=true failed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("unexpected status %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("valid CA file trusted against matching TLS server", func(t *testing.T) {
+		// httptest.NewTLSServer uses its own self-signed cert. We use the
+		// server's TLS config to extract the CA cert PEM and write it as
+		// our ca_file. This proves that the loaded pool is actually used.
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		// Extract the server's CA cert as PEM.
+		serverCert := srv.TLS.Certificates[0]
+		parsedCert, err := x509.ParseCertificate(serverCert.Certificate[0])
+		if err != nil {
+			t.Fatalf("parsing server cert: %v", err)
+		}
+		caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: parsedCert.Raw})
+		caPath := writeTempFile(t, "ca.pem", caPEM)
+
+		client, err := newORASHTTPClient(false, caPath, 0, 0)
+		if err != nil {
+			t.Fatalf("unexpected error building client: %v", err)
+		}
+
+		resp, err := client.Get(srv.URL) //nolint:noctx
+		if err != nil {
+			t.Fatalf("GET with custom CA file failed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("unexpected status %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("non-existent CA file returns error", func(t *testing.T) {
+		_, err := newORASHTTPClient(false, "/no/such/file.pem", 0, 0)
+		if err == nil {
+			t.Fatal("expected error for missing CA file, got nil")
+		}
+		if !strings.Contains(err.Error(), "reading ca_file") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("CA file with invalid PEM returns error", func(t *testing.T) {
+		badPath := writeTempFile(t, "bad.pem", []byte("not-valid-pem"))
+		_, err := newORASHTTPClient(false, badPath, 0, 0)
+		if err == nil {
+			t.Fatal("expected error for invalid PEM content, got nil")
+		}
+		if !strings.Contains(err.Error(), "no valid certificates") {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
 }

--- a/internal/backend/remote-state/oras/client_test.go
+++ b/internal/backend/remote-state/oras/client_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1507,4 +1508,167 @@ func (r *slowDeleteRepo) Delete(ctx context.Context, target ocispec.Descriptor) 
 		return ctx.Err()
 	}
 	return r.delegatingRepo.inner.Delete(ctx, target)
+}
+
+// ---------------------------------------------------------------------------
+// Edge case tests: Put with nil/empty state, workspaceNameFromTag with corrupt
+// manifest, and context cancellation during parallel workspace resolution.
+// ---------------------------------------------------------------------------
+
+// TestPut_nilAndEmptyState verifies that Put() accepts nil and empty state
+// without panicking or returning an error. Both represent "no state" and must
+// be stored as a valid (empty) layer so that subsequent Get() calls do not fail.
+func TestPut_nilAndEmptyState(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tc := range []struct {
+		name  string
+		state []byte
+	}{
+		{"nil state", nil},
+		{"empty slice", []byte{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := newFakeORASRepo()
+			repo := &orasRepositoryClient{inner: fake}
+			c := newRemoteClient(repo, "default")
+
+			if err := c.Put(ctx, tc.state); err != nil {
+				t.Fatalf("Put(%v) returned unexpected error: %v", tc.name, err)
+			}
+			// A subsequent Get must succeed and return the empty state payload.
+			got, err := c.Get(ctx)
+			if err != nil {
+				t.Fatalf("Get after Put(%v) returned error: %v", tc.name, err)
+			}
+			if got == nil {
+				t.Fatalf("Get after Put(%v) returned nil payload", tc.name)
+			}
+		})
+	}
+}
+
+// TestWorkspaceNameFromTag_corruptManifest verifies that workspaceNameFromTag
+// returns a descriptive error when the OCI manifest stored under a hashed
+// workspace tag contains invalid JSON.
+func TestWorkspaceNameFromTag_corruptManifest(t *testing.T) {
+	ctx := context.Background()
+	fake := newFakeORASRepo()
+
+	// A hashed workspace tag has the form tf-state-ws-XXXX. workspaceNameFromTag
+	// will try to Resolve+Fetch the manifest to read the annotation.
+	const tag = stateTagPrefix + "ws-abc123"
+
+	// Push a blob with corrupt (non-JSON) content and tag it.
+	corruptData := []byte("this is not valid JSON {{{")
+	dgst := digest.FromBytes(corruptData)
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    dgst,
+		Size:      int64(len(corruptData)),
+	}
+	if err := fake.Push(ctx, desc, bytes.NewReader(corruptData)); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if err := fake.Tag(ctx, desc, tag); err != nil {
+		t.Fatalf("Tag: %v", err)
+	}
+
+	repo := &orasRepositoryClient{inner: fake}
+	_, err := workspaceNameFromTag(ctx, repo, tag)
+	if err == nil {
+		t.Fatal("expected error for corrupt manifest, got nil")
+	}
+	if !strings.Contains(err.Error(), "decoding manifest") {
+		t.Errorf("expected 'decoding manifest' in error, got: %v", err)
+	}
+}
+
+// blockingRepo wraps fakeORASRepo and makes Resolve block until its context is
+// cancelled. Used by TestListWorkspacesFromTags_contextCancellation to simulate
+// a registry that hangs on manifest resolution.
+type blockingRepo struct {
+	delegatingRepo
+	// ready is closed by the test once all goroutines are guaranteed to be
+	// blocked inside Resolve, allowing the test to cancel the context at the
+	// right moment without a sleep.
+	ready chan struct{}
+	once  sync.Once
+}
+
+func (r *blockingRepo) Resolve(ctx context.Context, _ string) (ocispec.Descriptor, error) {
+	// Signal that at least one goroutine has reached the blocking point.
+	r.once.Do(func() { close(r.ready) })
+	// Block until the context is cancelled.
+	<-ctx.Done()
+	return ocispec.Descriptor{}, ctx.Err()
+}
+
+// TestListWorkspacesFromTags_contextCancellation verifies that
+// listWorkspacesFromTags propagates context cancellation correctly when the
+// parallel manifest-resolution goroutines are blocked.
+//
+// The test is deterministic: it cancels the context only after at least one
+// goroutine has entered the blocking Resolve call, so there are no sleeps.
+func TestListWorkspacesFromTags_contextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	fake := newFakeORASRepo()
+
+	// Populate several hashed workspace tags so that listWorkspacesFromTags
+	// spawns multiple parallel goroutines that will all hit blockingRepo.Resolve.
+	for i := range 5 {
+		tag := fmt.Sprintf("%sws-%04d", stateTagPrefix, i)
+		// The content and descriptor don't matter — the fake repo just needs a
+		// tag entry so that Tags() returns it.
+		data := []byte(fmt.Sprintf("manifest-%d", i))
+		dgst := digest.FromBytes(data)
+		desc := ocispec.Descriptor{Digest: dgst, Size: int64(len(data))}
+		if err := fake.Push(ctx, desc, bytes.NewReader(data)); err != nil {
+			t.Fatalf("Push tag %s: %v", tag, err)
+		}
+		if err := fake.Tag(ctx, desc, tag); err != nil {
+			t.Fatalf("Tag %s: %v", tag, err)
+		}
+	}
+
+	ready := make(chan struct{})
+	blocking := &blockingRepo{
+		delegatingRepo: delegatingRepo{inner: fake},
+		ready:          ready,
+	}
+	repo := &orasRepositoryClient{inner: blocking}
+
+	// Run listWorkspacesFromTags in a goroutine; collect the result.
+	type result struct {
+		workspaces []string
+		err        error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ws, err := listWorkspacesFromTags(ctx, repo)
+		ch <- result{ws, err}
+	}()
+
+	// Wait until at least one goroutine is blocked in Resolve, then cancel.
+	select {
+	case <-ready:
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for goroutines to reach blocking Resolve")
+	}
+
+	// Collect the result with a generous deadline.
+	select {
+	case res := <-ch:
+		if res.err == nil {
+			t.Fatal("expected context cancellation error, got nil")
+		}
+		if !errors.Is(res.err, context.Canceled) {
+			t.Errorf("expected context.Canceled, got: %v", res.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("listWorkspacesFromTags did not return after context cancellation")
+	}
 }


### PR DESCRIPTION
## Summary

Closes #51 — adds the missing edge case test coverage for the ORAS backend.

## New Tests

### `backend_test.go` — `TestNewORASHTTPClient` (5 subtests)

Covers `newORASHTTPClient()` TLS configuration paths that had no tests:

| Subtest | Verifies |
|---------|----------|
| default — no TLS options | Returns a non-nil client without error |
| insecure=true | Succeeds against a self-signed `httptest.TLSServer` (end-to-end, no transport introspection) |
| valid CA file | CA extracted from `httptest.TLSServer` cert is written to file and trusted |
| non-existent CA path | Returns error containing `"reading ca_file"` |
| invalid PEM content | Returns error containing `"no valid certificates"` |

The insecure and CA subtests are **functional** (real TLS handshake) rather than inspecting the transport chain, which makes them immune to changes in the `otelhttp`/`rateLimitedRoundTripper`/`userAgentRoundTripper` wrapping order.

### `client_test.go` — 3 new tests

**`TestPut_nilAndEmptyState`** — `Put()` with `nil` and `[]byte{}` must not panic and must produce a readable state layer (`Get()` succeeds afterward).

**`TestWorkspaceNameFromTag_corruptManifest`** — `workspaceNameFromTag()` with a hashed workspace tag whose blob contains invalid JSON must return an error containing `"decoding manifest"`.

**`TestListWorkspacesFromTags_contextCancellation`** — the `errgroup` parallel resolution in `listWorkspacesFromTags()` must propagate `context.Canceled` when cancelled mid-flight. Uses a channel-gate (`blockingRepo.ready`) for **deterministic synchronisation** — goroutines signal readiness before the test cancels, no sleeps.

## Test results

```
111 passed in internal/backend/remote-state/oras (race detector on)
0 linter issues
```