### PR TITLE
feat: propagate context to PlanGraphForUI, ApplyGraphForUI, and TestContext.evaluate

### DIFF
--- a/internal/command/graph.go
+++ b/internal/command/graph.go
@@ -12,10 +12,10 @@ import (
 	"github.com/vmvarela/ghoten/internal/backend"
 	"github.com/vmvarela/ghoten/internal/command/arguments"
 	"github.com/vmvarela/ghoten/internal/dag"
+	"github.com/vmvarela/ghoten/internal/ghoten"
 	"github.com/vmvarela/ghoten/internal/plans"
 	"github.com/vmvarela/ghoten/internal/plans/planfile"
 	"github.com/vmvarela/ghoten/internal/tfdiags"
-	"github.com/vmvarela/ghoten/internal/ghoten"
 )
 
 // GraphCommand is a Command implementation that takes a Ghoten
@@ -181,11 +181,11 @@ func (c *GraphCommand) Run(args []string) int {
 	var graphDiags tfdiags.Diagnostics
 	switch graphTypeStr {
 	case "plan":
-		g, graphDiags = lr.Core.PlanGraphForUI(lr.Config, lr.InputState, plans.NormalMode)
+		g, graphDiags = lr.Core.PlanGraphForUI(ctx, lr.Config, lr.InputState, plans.NormalMode)
 	case "plan-refresh-only":
-		g, graphDiags = lr.Core.PlanGraphForUI(lr.Config, lr.InputState, plans.RefreshOnlyMode)
+		g, graphDiags = lr.Core.PlanGraphForUI(ctx, lr.Config, lr.InputState, plans.RefreshOnlyMode)
 	case "plan-destroy":
-		g, graphDiags = lr.Core.PlanGraphForUI(lr.Config, lr.InputState, plans.DestroyMode)
+		g, graphDiags = lr.Core.PlanGraphForUI(ctx, lr.Config, lr.InputState, plans.DestroyMode)
 	case "apply":
 		plan := lr.Plan
 
@@ -201,7 +201,7 @@ func (c *GraphCommand) Run(args []string) int {
 			}
 		}
 
-		g, graphDiags = lr.Core.ApplyGraphForUI(plan, lr.Config)
+		g, graphDiags = lr.Core.ApplyGraphForUI(ctx, plan, lr.Config)
 	case "eval", "validate":
 		// Terraform v0.12 through v1.0 supported both of these, but the
 		// graph variants for "eval" and "validate" are purely implementation

--- a/internal/ghoten/context_apply.go
+++ b/internal/ghoten/context_apply.go
@@ -260,13 +260,13 @@ func (c *Context) applyGraph(ctx context.Context, plan *plans.Plan, config *conf
 // graph, and so may change in future in order to make the result more useful
 // in that context, even if drifts away from the physical graph that Ghoten
 // Core currently uses as an implementation detail of planning.
-func (c *Context) ApplyGraphForUI(plan *plans.Plan, config *configs.Config) (*Graph, tfdiags.Diagnostics) {
+func (c *Context) ApplyGraphForUI(ctx context.Context, plan *plans.Plan, config *configs.Config) (*Graph, tfdiags.Diagnostics) {
 	// For now though, this really is just the internal graph, confusing
 	// implementation details and all.
 
 	var diags tfdiags.Diagnostics
 
-	graph, _, moreDiags := c.applyGraph(context.TODO(), plan, config, make(ProviderFunctionMapping), nil)
+	graph, _, moreDiags := c.applyGraph(ctx, plan, config, make(ProviderFunctionMapping), nil)
 	diags = diags.Append(moreDiags)
 	return graph, diags
 }

--- a/internal/ghoten/context_plan.go
+++ b/internal/ghoten/context_plan.go
@@ -1082,7 +1082,7 @@ func (c *Context) driftedResources(ctx context.Context, config *configs.Config, 
 // graph, and so may change in future in order to make the result more useful
 // in that context, even if drifts away from the physical graph that Ghoten
 // Core currently uses as an implementation detail of planning.
-func (c *Context) PlanGraphForUI(config *configs.Config, prevRunState *states.State, mode plans.Mode) (*Graph, tfdiags.Diagnostics) {
+func (c *Context) PlanGraphForUI(ctx context.Context, config *configs.Config, prevRunState *states.State, mode plans.Mode) (*Graph, tfdiags.Diagnostics) {
 	// For now though, this really is just the internal graph, confusing
 	// implementation details and all.
 
@@ -1090,7 +1090,7 @@ func (c *Context) PlanGraphForUI(config *configs.Config, prevRunState *states.St
 
 	opts := &PlanOpts{Mode: mode}
 
-	graph, _, moreDiags := c.planGraph(context.TODO(), config, prevRunState, opts, make(ProviderFunctionMapping))
+	graph, _, moreDiags := c.planGraph(ctx, config, prevRunState, opts, make(ProviderFunctionMapping))
 	diags = diags.Append(moreDiags)
 	return graph, diags
 }

--- a/internal/ghoten/test_context.go
+++ b/internal/ghoten/test_context.go
@@ -59,17 +59,17 @@ func (c *Context) TestContext(config *configs.Config, state *states.State, plan 
 // this function.
 func (ctx *TestContext) EvaluateAgainstState(run *moduletest.Run) {
 	defer ctx.acquireRun("evaluate")()
-	ctx.evaluate(ctx.State.SyncWrapper(), plans.NewChanges().SyncWrapper(), run, walkApply)
+	ctx.evaluate(context.Background(), ctx.State.SyncWrapper(), plans.NewChanges().SyncWrapper(), run, walkApply)
 }
 
 // EvaluateAgainstPlan processes the assertions inside the provided
 // configs.TestRun against the embedded plan and state.
 func (ctx *TestContext) EvaluateAgainstPlan(run *moduletest.Run) {
 	defer ctx.acquireRun("evaluate")()
-	ctx.evaluate(ctx.State.SyncWrapper(), ctx.Plan.Changes.SyncWrapper(), run, walkPlan)
+	ctx.evaluate(context.Background(), ctx.State.SyncWrapper(), ctx.Plan.Changes.SyncWrapper(), run, walkPlan)
 }
 
-func (tc *TestContext) evaluate(state *states.SyncState, changes *plans.ChangesSync, run *moduletest.Run, operation walkOperation) {
+func (tc *TestContext) evaluate(ctx context.Context, state *states.SyncState, changes *plans.ChangesSync, run *moduletest.Run, operation walkOperation) {
 	// The state does not include the module that has no resources, making its outputs unusable.
 	// synchronizeStates function synchronizes the state with the planned state, ensuring inclusion of all modules.
 	if tc.Plan != nil && tc.Plan.PlannedState != nil &&
@@ -130,7 +130,7 @@ func (tc *TestContext) evaluate(state *states.SyncState, changes *plans.ChangesS
 		diags = diags.Append(moreDiags)
 		refs = append(refs, moreRefs...)
 
-		hclCtx, moreDiags := scope.EvalContext(context.TODO(), refs)
+		hclCtx, moreDiags := scope.EvalContext(ctx, refs)
 		diags = diags.Append(moreDiags)
 
 		errorMessage, moreDiags := evalCheckErrorMessage(rule.ErrorMessage, hclCtx)


### PR DESCRIPTION
## Summary

Part of #47 (context propagation series).

- **`PlanGraphForUI`** — adds `ctx context.Context` parameter, threads it to `planGraph`, eliminating `context.TODO()`
- **`ApplyGraphForUI`** — same for `applyGraph`
- **`TestContext.evaluate`** — takes `ctx context.Context`; the `scope.EvalContext` call now uses the propagated context instead of `context.TODO()`; public callers (`EvaluateAgainstState`, `EvaluateAgainstPlan`) pass `context.Background()` since they are invoked from the test framework without a live cancellable context
- **`internal/command/graph.go`** — passes its live `ctx` to both `PlanGraphForUI` and `ApplyGraphForUI`

All 1624 ghoten tests and 2724 command tests pass with `-race`.

Closes #77