### PR TITLE
feat: semantic evaluation for smart refresh via attribute reference tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,23 @@ echo "$GITHUB_TOKEN" | docker login ghcr.io -u YOUR_GITHUB_USER --password-stdin
 - **Safe by default**: locking, retries, and optional compression are built in.
 - **Works in GitHub Actions**: action handles install, auth, init, PR comments, and summaries.
 
+## Smart Refresh
+
+Ghoten includes a `-refresh=smart` flag that speeds up `plan` and `apply` operations in large infrastructures by skipping refresh for resources whose configuration hasn't changed:
+
+```bash
+# Refresh all resources (default behavior)
+ghoten plan
+
+# Skip refresh entirely
+ghoten plan -refresh=false
+
+# Smart refresh: only refresh resources with config changes and their dependents
+ghoten plan -refresh=smart
+```
+
+Smart refresh compares a hash of each resource's configuration expression to detect structural changes. When no changes are detected, the resource is skipped, reducing API calls and execution time. The output shows how many resources were refreshed vs. skipped.
+
 ## Documentation
 
 - [Quickstart & installation](docs/quickstart.md)

--- a/internal/ghoten/transform_smart_refresh.go
+++ b/internal/ghoten/transform_smart_refresh.go
@@ -149,6 +149,7 @@ func (t *SmartRefreshTransformer) applyRefreshSet(g *Graph, refreshSet dag.Set) 
 func (t *SmartRefreshTransformer) identifyChangedNodes(g *Graph) dag.Set {
 	changed := make(dag.Set)
 
+	// First pass: identify directly changed nodes (new, orphan, hash mismatch).
 	for _, v := range g.Vertices() {
 		rn, ok := v.(GraphNodeConfigResource)
 		if !ok {
@@ -190,7 +191,62 @@ func (t *SmartRefreshTransformer) identifyChangedNodes(g *Graph) dag.Set {
 		}
 	}
 
+	// Second pass: add nodes that reference a changed node via attribute
+	// expressions. If aws_instance.web has ami = aws_instance.base.ami and
+	// base is in changed, web must also be refreshed — its evaluated value
+	// may differ when base is read from remote.
+	//
+	// This is done iteratively (fixed-point) to handle chains: if A → B → C
+	// and C changes, both B and A must be marked as changed. A single pass
+	// would only catch B if it processes A before B is added to changed.
+	//
+	// ReferenceTransformer already built the necessary edges (it covers
+	// attribute references, not just depends_on), so g.Ancestors(v) gives
+	// us the full closure.
+	for {
+		newlyAdded := make(dag.Set)
+		for _, v := range g.Vertices() {
+			if changed.Include(v) {
+				continue // already in changed set
+			}
+			rn, ok := v.(GraphNodeConfigResource)
+			if !ok {
+				continue
+			}
+			if rn.ResourceAddr().Resource.Mode != addrs.ManagedResourceMode {
+				continue // only managed resources need refresh
+			}
+			if t.referencesChangedNode(g, v, changed) {
+				newlyAdded.Add(v)
+				log.Printf("[DEBUG] SmartRefreshTransformer: %q references a changed node, marking for refresh", dag.VertexName(v))
+			}
+		}
+		if len(newlyAdded) == 0 {
+			break // fixed point reached
+		}
+		for _, v := range newlyAdded {
+			changed.Add(v)
+		}
+	}
+
 	return changed
+}
+
+// referencesChangedNode returns true if the given vertex has at least one
+// ancestor that is already in changedNodes. The dependency edges exist
+// because ReferenceTransformer ran before this transformer, connecting
+// attribute-level references (e.g. ami = base.ami), not just depends_on.
+func (t *SmartRefreshTransformer) referencesChangedNode(g *Graph, v dag.Vertex, changedNodes dag.Set) bool {
+	ancestors, err := g.Ancestors(v)
+	if err != nil {
+		return false
+	}
+	for _, a := range ancestors {
+		if changedNodes.Include(a) {
+			return true
+		}
+	}
+	return false
 }
 
 // configBodyChanged returns true if the resource's structural meta-arguments

--- a/internal/ghoten/transform_smart_refresh_test.go
+++ b/internal/ghoten/transform_smart_refresh_test.go
@@ -309,15 +309,402 @@ func TestGraphNodeSkipRefreshInterface(t *testing.T) {
 	var _ GraphNodeSkipRefresh = (*NodePlanDeposedResourceInstanceObject)(nil)
 }
 
+// --- Semantic evaluation tests ---
+
+// mockGraphNodeConfigResource is a mock node implementing GraphNodeConfigResource.
+type mockGraphNodeConfigResource struct {
+	name        string
+	addr        addrs.ConfigResource
+	skipRefresh bool
+}
+
+func (n *mockGraphNodeConfigResource) Name() string                       { return n.name }
+func (n *mockGraphNodeConfigResource) SetSkipRefresh(v bool)              { n.skipRefresh = v }
+func (n *mockGraphNodeConfigResource) ResourceAddr() addrs.ConfigResource { return n.addr }
+
+var _ GraphNodeSkipRefresh = (*mockGraphNodeConfigResource)(nil)
+var _ GraphNodeConfigResource = (*mockGraphNodeConfigResource)(nil)
+
+func TestSmartRefreshTransformer_ReferencesChangedNode(t *testing.T) {
+	// When base is in the changed set (hash mismatch), and web has an attribute
+	// reference to base (edge web -> base), web must also be marked as changed.
+	g := &Graph{Path: addrs.RootModuleInstance}
+
+	baseAddr := addrs.ConfigResource{
+		Module: addrs.RootModule,
+		Resource: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "base",
+		},
+	}
+	webAddr := addrs.ConfigResource{
+		Module: addrs.RootModule,
+		Resource: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "web",
+		},
+	}
+	unrelatedAddr := addrs.ConfigResource{
+		Module: addrs.RootModule,
+		Resource: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "unrelated",
+		},
+	}
+
+	base := &mockGraphNodeConfigResource{name: "aws_instance.base", addr: baseAddr}
+	web := &mockGraphNodeConfigResource{name: "aws_instance.web", addr: webAddr}
+	unrelated := &mockGraphNodeConfigResource{name: "aws_instance.unrelated", addr: unrelatedAddr}
+
+	g.Add(base)
+	g.Add(web)
+	g.Add(unrelated)
+
+	// Edge: web -> base (web references base)
+	g.Connect(dag.BasicEdge(web, base))
+
+	// State with base having a mismatched hash (forcing it into changed set)
+	baseConfig := makeTestResourceNamed("base", nil, nil, nil)
+	baseCorrectHash := configExprHash(baseConfig)
+	// Create a different hash by modifying one byte
+	baseWrongHash := make([]byte, len(baseCorrectHash))
+	copy(baseWrongHash, baseCorrectHash)
+	baseWrongHash[0] ^= 0xFF // Flip bits in first byte to make it different
+
+	state := states.BuildState(func(s *states.SyncState) {
+		// base: hash mismatch - will be in changed
+		s.SetResourceInstanceCurrent(
+			baseAddr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				Status:         states.ObjectReady,
+				AttrsJSON:      []byte(`{"id":"old-id"}`),
+				ConfigExprHash: baseWrongHash, // Hash mismatch - will be in changed
+			},
+			addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.NewDefaultProvider("aws"),
+			},
+			addrs.NoKey,
+		)
+		// web: hash matches current config (will reference base via edge)
+		webConfig := makeTestResourceNamed("web", nil, nil, nil)
+		s.SetResourceInstanceCurrent(
+			webAddr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				Status:         states.ObjectReady,
+				AttrsJSON:      []byte(`{"id":"web-id"}`),
+				ConfigExprHash: configExprHash(webConfig), // Matching hash
+			},
+			addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.NewDefaultProvider("aws"),
+			},
+			addrs.NoKey,
+		)
+		// unrelated: hash matches current config (no edge to base)
+		unrelatedConfig := makeTestResourceNamed("unrelated", nil, nil, nil)
+		s.SetResourceInstanceCurrent(
+			unrelatedAddr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				Status:         states.ObjectReady,
+				AttrsJSON:      []byte(`{"id":"unrelated-id"}`),
+				ConfigExprHash: configExprHash(unrelatedConfig), // Matching hash
+			},
+			addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.NewDefaultProvider("aws"),
+			},
+			addrs.NoKey,
+		)
+	})
+
+	// Config matching base's current config (hash mismatch forces base into changed)
+	cfg := &configs.Config{
+		Module: &configs.Module{
+			ManagedResources: map[string]*configs.Resource{
+				"aws_instance.base":      makeTestResourceNamed("base", nil, nil, nil),
+				"aws_instance.web":       makeTestResourceNamed("web", nil, nil, nil),
+				"aws_instance.unrelated": makeTestResourceNamed("unrelated", nil, nil, nil),
+			},
+		},
+	}
+
+	tf := &SmartRefreshTransformer{
+		Active: true,
+		State:  state,
+		Config: cfg,
+	}
+
+	if err := tf.Transform(t.Context(), g); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// base: should be refreshed (hash mismatch)
+	if base.skipRefresh {
+		t.Errorf("base.skipRefresh should be false (hash mismatch, changed node)")
+	}
+
+	// web: should be refreshed because it references base via attribute edge
+	if web.skipRefresh {
+		t.Errorf("web.skipRefresh should be false (references changed node base)")
+	}
+
+	// unrelated: should be skipped (no reference to changed nodes)
+	if !unrelated.skipRefresh {
+		t.Errorf("unrelated.skipRefresh should be true (no reference to changed nodes)")
+	}
+}
+
+func TestSmartRefreshTransformer_ReferencesChangedNode_NoFalsePositive(t *testing.T) {
+	// Verify that nodes without edges to changed nodes are not marked as changed.
+	g := &Graph{Path: addrs.RootModuleInstance}
+
+	baseAddr := addrs.ConfigResource{
+		Module: addrs.RootModule,
+		Resource: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "base",
+		},
+	}
+	unrelatedAddr := addrs.ConfigResource{
+		Module: addrs.RootModule,
+		Resource: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "unrelated",
+		},
+	}
+
+	base := &mockGraphNodeConfigResource{name: "aws_instance.base", addr: baseAddr}
+	unrelated := &mockGraphNodeConfigResource{name: "aws_instance.unrelated", addr: unrelatedAddr}
+
+	g.Add(base)
+	g.Add(unrelated)
+
+	// No edge between them
+
+	// State with base having a mismatched hash (forcing it into changed set)
+	baseConfig := makeTestResourceNamed("base", nil, nil, nil)
+	baseCorrectHash := configExprHash(baseConfig)
+	// Create a different hash by modifying one byte
+	baseWrongHash := make([]byte, len(baseCorrectHash))
+	copy(baseWrongHash, baseCorrectHash)
+	baseWrongHash[0] ^= 0xFF // Flip bits in first byte to make it different
+
+	state := states.BuildState(func(s *states.SyncState) {
+		// base: hash mismatch - will be in changed
+		s.SetResourceInstanceCurrent(
+			baseAddr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				Status:         states.ObjectReady,
+				AttrsJSON:      []byte(`{"id":"old-id"}`),
+				ConfigExprHash: baseWrongHash, // Will not match current config
+			},
+			addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.NewDefaultProvider("aws"),
+			},
+			addrs.NoKey,
+		)
+		// unrelated: hash matches current config (no edge to base)
+		unrelatedConfig := makeTestResourceNamed("unrelated", nil, nil, nil)
+		s.SetResourceInstanceCurrent(
+			unrelatedAddr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				Status:         states.ObjectReady,
+				AttrsJSON:      []byte(`{"id":"unrelated-id"}`),
+				ConfigExprHash: configExprHash(unrelatedConfig), // Matching hash
+			},
+			addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.NewDefaultProvider("aws"),
+			},
+			addrs.NoKey,
+		)
+	})
+
+	cfg := &configs.Config{
+		Module: &configs.Module{
+			ManagedResources: map[string]*configs.Resource{
+				"aws_instance.base":      makeTestResourceNamed("base", nil, nil, nil),
+				"aws_instance.unrelated": makeTestResourceNamed("unrelated", nil, nil, nil),
+			},
+		},
+	}
+
+	tf := &SmartRefreshTransformer{
+		Active: true,
+		State:  state,
+		Config: cfg,
+	}
+
+	if err := tf.Transform(t.Context(), g); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// base: should be refreshed (hash mismatch)
+	if base.skipRefresh {
+		t.Errorf("base.skipRefresh should be false (hash mismatch)")
+	}
+
+	// unrelated: should be skipped (no reference to changed nodes)
+	if !unrelated.skipRefresh {
+		t.Errorf("unrelated.skipRefresh should be true (no edge to changed node)")
+	}
+}
+
+func TestSmartRefreshTransformer_ReferencesChangedNode_Chain(t *testing.T) {
+	// Verify that the second pass is transitive: A → B → C, C changes,
+	// both B and A should be marked as changed.
+	g := &Graph{Path: addrs.RootModuleInstance}
+
+	leafAddr := addrs.ConfigResource{
+		Module: addrs.RootModule,
+		Resource: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "leaf",
+		},
+	}
+	middleAddr := addrs.ConfigResource{
+		Module: addrs.RootModule,
+		Resource: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "middle",
+		},
+	}
+	rootAddr := addrs.ConfigResource{
+		Module: addrs.RootModule,
+		Resource: addrs.Resource{
+			Mode: addrs.ManagedResourceMode,
+			Type: "aws_instance",
+			Name: "root",
+		},
+	}
+
+	leaf := &mockGraphNodeConfigResource{name: "aws_instance.leaf", addr: leafAddr}
+	middle := &mockGraphNodeConfigResource{name: "aws_instance.middle", addr: middleAddr}
+	root := &mockGraphNodeConfigResource{name: "aws_instance.root", addr: rootAddr}
+
+	g.Add(leaf)
+	g.Add(middle)
+	g.Add(root)
+
+	// Edges: middle → leaf, root → middle
+	g.Connect(dag.BasicEdge(middle, leaf))
+	g.Connect(dag.BasicEdge(root, middle))
+
+	// State with leaf having a mismatched hash (forcing it into changed set)
+	leafConfig := makeTestResourceNamed("leaf", nil, nil, nil)
+	leafCorrectHash := configExprHash(leafConfig)
+	// Create a different hash by modifying one byte
+	leafWrongHash := make([]byte, len(leafCorrectHash))
+	copy(leafWrongHash, leafCorrectHash)
+	leafWrongHash[0] ^= 0xFF // Flip bits in first byte to make it different
+
+	state := states.BuildState(func(s *states.SyncState) {
+		// leaf: hash mismatch - will be in changed
+		s.SetResourceInstanceCurrent(
+			leafAddr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				Status:         states.ObjectReady,
+				AttrsJSON:      []byte(`{"id":"leaf-id"}`),
+				ConfigExprHash: leafWrongHash, // Hash mismatch - will be in changed
+			},
+			addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.NewDefaultProvider("aws"),
+			},
+			addrs.NoKey,
+		)
+		// middle: hash matches current config (will reference leaf via edge)
+		middleConfig := makeTestResourceNamed("middle", nil, nil, nil)
+		s.SetResourceInstanceCurrent(
+			middleAddr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				Status:         states.ObjectReady,
+				AttrsJSON:      []byte(`{"id":"middle-id"}`),
+				ConfigExprHash: configExprHash(middleConfig), // Matching hash
+			},
+			addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.NewDefaultProvider("aws"),
+			},
+			addrs.NoKey,
+		)
+		// root: hash matches current config (will reference middle via edge)
+		rootConfig := makeTestResourceNamed("root", nil, nil, nil)
+		s.SetResourceInstanceCurrent(
+			rootAddr.Resource.Instance(addrs.NoKey).Absolute(addrs.RootModuleInstance),
+			&states.ResourceInstanceObjectSrc{
+				Status:         states.ObjectReady,
+				AttrsJSON:      []byte(`{"id":"root-id"}`),
+				ConfigExprHash: configExprHash(rootConfig), // Matching hash
+			},
+			addrs.AbsProviderConfig{
+				Module:   addrs.RootModule,
+				Provider: addrs.NewDefaultProvider("aws"),
+			},
+			addrs.NoKey,
+		)
+	})
+
+	cfg := &configs.Config{
+		Module: &configs.Module{
+			ManagedResources: map[string]*configs.Resource{
+				"aws_instance.leaf":   makeTestResourceNamed("leaf", nil, nil, nil),
+				"aws_instance.middle": makeTestResourceNamed("middle", nil, nil, nil),
+				"aws_instance.root":   makeTestResourceNamed("root", nil, nil, nil),
+			},
+		},
+	}
+
+	tf := &SmartRefreshTransformer{
+		Active: true,
+		State:  state,
+		Config: cfg,
+	}
+
+	if err := tf.Transform(t.Context(), g); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+
+	// leaf: should be refreshed (hash mismatch, changed node)
+	if leaf.skipRefresh {
+		t.Errorf("leaf.skipRefresh should be false (hash mismatch, changed node)")
+	}
+
+	// middle: should be refreshed because it references leaf
+	if middle.skipRefresh {
+		t.Errorf("middle.skipRefresh should be false (references changed node leaf)")
+	}
+
+	// root: should be refreshed because it references middle (which references leaf)
+	// This requires the iterative/fixed-point algorithm
+	if root.skipRefresh {
+		t.Errorf("root.skipRefresh should be false (references middle which references changed node)")
+	}
+}
+
 // --- configExprHash tests ---
 
 // makeTestResource builds a minimal configs.Resource suitable for
-// configExprHash tests.
+// configExprHash tests. Uses "web" as the default name.
 func makeTestResource(count, forEach hcl.Expression, dependsOn []hcl.Traversal) *configs.Resource {
+	return makeTestResourceNamed("web", count, forEach, dependsOn)
+}
+
+// makeTestResourceNamed builds a configs.Resource with a specific name.
+func makeTestResourceNamed(name string, count, forEach hcl.Expression, dependsOn []hcl.Traversal) *configs.Resource {
 	return &configs.Resource{
 		Mode:      addrs.ManagedResourceMode,
 		Type:      "aws_instance",
-		Name:      "web",
+		Name:      name,
 		Config:    configs.SynthBody("", map[string]cty.Value{}),
 		Count:     count,
 		ForEach:   forEach,


### PR DESCRIPTION
## Summary

This PR adds semantic evaluation to the smart refresh feature by propagating refresh requirements to resources that reference changed nodes via attribute expressions, using a **fixed-point iteration algorithm** to correctly handle dependency chains.

## Problem

The `SmartRefreshTransformer` uses `configExprHash` which only captures structural meta-arguments (`count`, `for_each`, `depends_on`). It does **not** capture attribute expressions like `ami = var.ami` or `tags = merge(local.common, {...})`.

When `skipRefresh=true`:
1. `ReadResource` is skipped
2. Prior state is used for diff computation  
3. Config expressions are evaluated against prior state (not remote state)
4. Remote drift goes undetected

**Chain Problem (now fixed):**
- A → B → C dependency chain
- C changes (hash mismatch)
- B references C (edge B→C)
- A references B (edge A→B)
- Single pass: catches B, misses A
- Fixed-point: catches both B and A ✓

## Solution

Added a second pass in `identifyChangedNodes` that iterates until a fixed point is reached:

```
changed = {directly changed nodes}
repeat:
    newlyAdded = {}
    for each node v not in changed:
        if v references any node in changed:
            newlyAdded.add(v)
    changed.addAll(newlyAdded)
until newlyAdded is empty
```

**Key changes:**
1. New `referencesChangedNode()` helper checks if a vertex has any ancestor in the changed set
2. **Iterative second pass** that handles chains of arbitrary length
3. `ReferenceTransformer` already built the necessary edges

## Testing

Added three test cases:
- `TestSmartRefreshTransformer_ReferencesChangedNode`: Verifies propagation via graph edge
- `TestSmartRefreshTransformer_ReferencesChangedNode_NoFalsePositive`: Verifies no false positives  
- `TestSmartRefreshTransformer_ReferencesChangedNode_Chain`: Verifies transitive chains (A→B→C)

All existing smart refresh tests continue to pass.

## Trade-offs

- **Pros:** Catches attribute-level dependencies, ensures semantic changes propagate transitively
- **Cons:** May over-refresh in some cases (conservative/safe approach)

Closes #128
